### PR TITLE
world.removeCollider fix

### DIFF
--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -322,7 +322,7 @@ export class World {
      * @param body - The collider to remove.
      */
     public removeCollider(collider: Collider) {
-        this.physicsPipeline.removeRigidBody(
+        this.physicsPipeline.removeCollider(
             collider.handle,
             this.broadPhase,
             this.narrowPhase,


### PR DESCRIPTION
Calls to World.removeCollider currently fail because the wrong method on physics pipeline is invoked. This PR fixes the call.
