### PR TITLE
Webpack based build system, inline wasm as base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+rapier2d/compat
+rapier3d/compat
 **/*.rs.bk
 Cargo.lock
 node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "build-rapier",
+  "description": "Build scripts for compatibility package with inlined webassembly as base64.",
+  "private": true,
+  "scripts": {
+    "build-rust-2d": "cd rapier2d ; wasm-pack build --target web",
+    "build-rust-3d": "cd rapier3d ; wasm-pack build --target web",
+    "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
+    "build": "npm run clean && npm run build-rust && webpack",
+    "clean": "rimraf rapier2d/pkg rapier3d/pkg rapier2d/compat rapier3d/compat rapier2d/docs rapier3d/docs",
+    "all": "npm run build"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^7.0.0",
+    "create-file-webpack": "^1.0.2",
+    "file-loader": "^6.2.0",
+    "rimraf": "^3.0.2",
+    "ts-loader": "^8.0.12",
+    "typescript": "^4.1.3",
+    "url-loader": "^4.1.1",
+    "webpack": "^5.11.0",
+    "webpack-cli": "^4.3.0"
+  }
+}

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -325,4 +325,4 @@ export class Cone {
     }
 }
 
-// #if endif
+// #endif

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,151 @@
+const CreateFileWebpack = require("create-file-webpack");
+const CopyPlugin = require("copy-webpack-plugin");
+const path = require("path");
+
+function matchOtherDimRegex({ is2d }) {
+  if (is2d) {
+    return /^ *\/\/ *#if +DIM3[\s\S]*?(?=#endif)#endif/gm;
+  } else {
+    return /^ *\/\/ *#if +DIM2[\s\S]*?(?=#endif)#endif/gm;
+  }
+}
+
+function initCode({ is2d }) {
+  let dim = is2d ? "2d" : "3d";
+
+  return `
+// @ts-ignore
+import wasmBase64 from "url-loader!./rapier_wasm${dim}_bg.wasm";
+import wasmInit from "./rapier_wasm${dim}";
+
+/**
+ * Initializes RAPIER.
+ * Has to be called and awaited before using any library methods.
+ */
+export async function init() {
+  let base64 = (wasmBase64 as string).replace(
+    "data:application/wasm;base64,",
+    ""
+  );
+  let bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  await wasmInit(bytes);
+}
+`;
+}
+
+function copyAndReplace({ is2d }) {
+  let dim = is2d ? "2d" : "3d";
+
+  return {
+    mode: "production",
+    entry: {},
+    plugins: [
+      new CopyPlugin({
+        patterns: [
+          // copy src.ts into pkg for compiling,
+          // remove sections wrapped in #ifdef DIMx ... #endif
+          // add init() function to rapier.ts
+          {
+            from: path.resolve(__dirname, "src.ts"),
+            to: path.resolve(__dirname, `rapier${dim}/pkg/`),
+            transform(content, path) {
+              let result = content
+                .toString()
+                .replace(matchOtherDimRegex({ is2d }), "");
+
+              if (path.endsWith("/rapier.ts")) {
+                result += initCode({ is2d });
+              }
+              return result;
+            },
+          },
+          // copy typescript sources into compat to support source mapping (see #3)
+          {
+            from: path.resolve(__dirname, "src.ts"),
+            to: path.resolve(__dirname, `rapier${dim}/compat/`),
+            transform(content) {
+              return content
+                .toString()
+                .replace(matchOtherDimRegex({ is2d }), "");
+            },
+            filter: (path) => !path.endsWith("raw.ts"),
+          },
+          // copy package.json, adapting entries, LICENSE and README.md
+          {
+            from: path.resolve(__dirname, `rapier${dim}/pkg/package.json`),
+            to: path.resolve(__dirname, `rapier${dim}/compat/package.json`),
+            transform(content) {
+              let config = JSON.parse(content.toString());
+              config.name = `@dimforge/rapier${dim}-compat`;
+              config.types = "rapier.d.ts";
+              config.main = "rapier.js";
+              config.files = ["*"];
+              delete config.module;
+
+              return JSON.stringify(config, undefined, 2);
+            },
+          },
+          {
+            from: path.resolve(__dirname, `rapier${dim}/pkg/LICENSE`),
+            to: path.resolve(__dirname, `rapier${dim}/compat/`),
+          },
+          {
+            from: path.resolve(__dirname, `rapier${dim}/pkg/README.md`),
+            to: path.resolve(__dirname, `rapier${dim}/compat/README.md`),
+          },
+        ],
+      }),
+      // ts files import from raw.ts, create the file reexporting the wasm-bindgen exports.
+      // the indirection simplifies switching between 2d and 3d
+      new CreateFileWebpack({
+        path: `./rapier${dim}/pkg/`,
+        fileName: "raw.ts",
+        content: `export * from "./rapier_wasm${dim}"`,
+      }),
+    ],
+  };
+}
+
+function compile({ is2d }) {
+  let dim = is2d ? "2d" : "3d";
+
+  return {
+    mode: "production",
+    entry: path.resolve(__dirname, `rapier${dim}/pkg/rapier.ts`),
+
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          loader: "ts-loader",
+          exclude: /node_modules/,
+          options: {
+            compilerOptions: {
+              outDir: "./compat",
+              lib: ["es5", "DOM"],
+            },
+          },
+        },
+      ],
+    },
+    resolve: {
+      extensions: [".tsx", ".ts", ".js"],
+    },
+    output: {
+      filename: "rapier.js",
+      path: path.resolve(__dirname, `rapier${dim}/compat`),
+      library: "RAPIER",
+      libraryTarget: "umd",
+    },
+  };
+}
+
+module.exports = [
+  // 2d
+  copyAndReplace({ is2d: true }),
+  compile({ is2d: true }),
+
+  // 3d
+  copyAndReplace({ is2d: false }),
+  compile({ is2d: false }),
+];


### PR DESCRIPTION
I had some trouble getting bundlers to work with the `.wasm` file: parcel did not work at all, and webpack requires an experiment "syncWebAssembly", but then type definitions did not work. The newer "asyncWebAssembly" also does not work.

Until bundlers are ready I think it would be easier to include the WebAssembly file as base64 and load it explicitly.
This PR replaces the build scripts with a package.json and webpack based build which
* Inlines the wasm as base64
* Minifies
* Outputs an UMD library which can be used with bundlers and in browsers directly by using a script tag
* Works on more plattforms (on macOS `sed` requires different parameters)

This way the library is easier to use and you could offer examples on Codepen because no bundler is required.

The downsides are:
* before using any library functions `await RAPIER.init()` needs to be called and awaited
* base64 increases the file size. When compressing it with gzip the difference is not as big, although I did not measure it.

When bundlers are ready you could switch back to use the `.wasm` file and make the `init` function empty and deprecated, or just remove it.

I committed the artefacts in this [branch](https://github.com/maun/rapier.js/tree/base64-artifacts). See `rapier2d/dist (docs)` and `rapier3d/dist (docs)`