### PR TITLE
Various minor fixes and snapshotting performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v0.3.1
+- Fix crash happening when creating a collider with a `ColliderDesc.convexHull` shape.
+- Actually remove the second argument of `RigidBodyDesc.setMass` as mentioned in the 0.3.0 changelog.
+- Improve snapshotting performances.
+
 ### v0.3.0
 #### Added
 - Added a `RAPIER.version()` function at the root of the package to retrieve the version of Rapier

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -646,21 +646,10 @@ export class RigidBodyDesc {
     /**
      * Sets the mass of the rigid-body being built.
      *
-     * Use `this.setMass(0.0, false)` to disable translations for this
-     * collider.
-     *
-     * Note that if `collidierMassContributionEnabled` is set to `true` then
-     * the final mass of the rigid-bodies depends on the initial mass set by
-     * this method to which is added the contributions of all the colliders
-     * with non-zero density attached to this rigid-body.
-     *
      * @param mass − The initial mass of the rigid-body to create.
-     * @param translationsEnabled - If `true`, then mass contributions from colliders
-     *   with non-zero densities will be taken into account.
      */
-    public setMass(mass: number, translationsEnabled: boolean): RigidBodyDesc {
+    public setMass(mass: number): RigidBodyDesc {
         this.mass = mass;
-        this.translationsEnabled = translationsEnabled;
         return this;
     }
 

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -558,9 +558,9 @@ export class ConvexPolyhedron {
 
     public intoRaw(): RawShape {
         if (!!this.indices) {
-            return RawShape.convexHull(this.vertices);
-        } else {
             return RawShape.convexMesh(this.vertices, this.indices);
+        } else {
+            return RawShape.convexHull(this.vertices);
         }
     }
 }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -51,7 +51,7 @@ impl RawColliderSet {
             ShapeType::RoundConvexPolyhedron => RawShapeType::RoundConvexPolyhedron,
             #[cfg(feature = "dim2")]
             ShapeType::RoundConvexPolygon => RawShapeType::RoundConvexPolygon,
-            ShapeType::HalfSpace => panic!("Not yet implemented."),
+            ShapeType::HalfSpace | ShapeType::Custom => panic!("Not yet implemented."),
         })
     }
 

--- a/testbed3d/src/demos/lockedRotations.js
+++ b/testbed3d/src/demos/lockedRotations.js
@@ -20,7 +20,6 @@ export function initWorld(RAPIER, testbed) {
     bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
         .setTranslation(0.0, 3.0, 0.0)
         .lockTranslations()
-        .setPrincipalAngularInertia(new RAPIER.Vector3(0.0, 0.0, 0.0))
         .restrictRotations(true, false, false);
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.cuboid(0.2, 0.6, 2.0);


### PR DESCRIPTION
- Fix crash happening when creating a collider with a `ColliderDesc.convexHull` shape.
- Actually remove the second argument of `RigidBodyDesc.setMass` as mentioned in the 0.3.0 changelog.
- Improve snapshotting performances.