### PR TITLE
Replaced the `sed` command in build_typescript.sh.

### DIFF
--- a/rapier2d/build_typescript.sh
+++ b/rapier2d/build_typescript.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 cp -r ../src.ts/* pkg/.
+node ../scripts/copy_src.js pkg ../src.ts DIM2
 echo 'export * from "./rapier_wasm2d"' >pkg/raw.ts
-find pkg/ -type f -print0 | xargs -0 sed -i '/^ *\/\/ #if DIM3/,/^ *\/\/ #endif/{/^ *\/\/ #if DIM3/!{/^ *\/\/ #endif/!d}}'
 tsc
 # NOTE: we keep the typescripts files into the NPM package for source mapping: see #3
 sed -i 's/"module": "rapier_wasm2d.js"/"module": "rapier.js"/g' pkg/package.json

--- a/rapier3d/build_typescript.sh
+++ b/rapier3d/build_typescript.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 cp -r ../src.ts/* pkg/.
+node ../scripts/copy_src.js pkg ../src.ts DIM3
 echo 'export * from "./rapier_wasm3d"' >pkg/raw.ts
-find pkg/ -type f -print0 | xargs -0 sed -i '/^ *\/\/ #if DIM2/,/^ *\/\/ #endif/{/^ *\/\/ #if DIM2/!{/^ *\/\/ #endif/!d}}'
 tsc
 # NOTE: we keep the typescripts files into the NPM package for source mapping: see #3
-sed -i 's/"module": "rapier_wasm3d.js"/"module": "rapier.js"/g' pkg/package.json
-sed -i 's/"types": "rapier_wasm3d.d.ts"/"types": "rapier.d.ts"/g' pkg/package.json
+sed -i '' 's/"module": "rapier_wasm3d.js"/"module": "rapier.js"/g' 'pkg/package.json'
+sed -i '' 's/"types": "rapier_wasm3d.d.ts"/"types": "rapier.d.ts"/g' 'pkg/package.json'

--- a/scripts/copy_src.js
+++ b/scripts/copy_src.js
@@ -1,0 +1,68 @@
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+const dstRoot = args.shift(); // Destination directory
+const srcRoot = args.shift(); // Source directory
+const defines = args; // List of #defined names
+
+if (!dstRoot) {
+  throw Error("Output directory not specified!");
+}
+
+if (!srcRoot) {
+  throw Error("Source directory not specified!");
+}
+
+function copy_files(dstDir, srcDir) {
+  fs.readdir(srcDir, (err, files) => {
+    if (err) {
+      console.log(`Error reading directory ${srcDir}:`, err);
+      process.exit(-1);
+    }
+    files.forEach((fname) => {
+      const inPath = path.join(srcDir, fname);
+      const outPath = path.join(dstDir, fname);
+      const stats = fs.statSync(inPath);
+      if (stats.isFile()) {
+        const content = fs.readFileSync(inPath, 'utf8');
+        const lines = content.split(/\r?\n/);
+        const out = [];
+        let ifNesting = 0;
+        for (let i = 0, ct = lines.length; i < ct; i++) {
+          const l = lines[i];
+          // Match #if
+          const m = /\/\/\s*#if\s+(\w+)/.exec(l);
+          if (m) {
+            if (!defines.includes(m[1])) {
+              ifNesting += 1;
+            }
+            continue;
+          }
+
+          // Match #endif
+          const m2 = /\/\/\s*#endif/.exec(l);
+          if (m2) {
+            if (ifNesting > 0) {
+              ifNesting -= 1;
+            }
+            continue;
+          }
+
+          // Only output if not in a disabled block
+          if (ifNesting === 0) {
+            out.push(l);
+          }
+        }
+
+        fs.writeFileSync(outPath, out.join('\n'), 'utf8');
+        console.log(`Wrote: ${outPath}`);
+      } else if (stats.isDirectory()) {
+        // Recurse into subdir
+        copy_files(path.join(dstDir, fname), inPath);
+      }
+    });
+  });
+}
+
+copy_files(dstRoot, srcRoot);


### PR DESCRIPTION
The `sed` command as written will only work on Linux/GNU variants
of `sed`, and is incompatile with BSD / OSX variants of sed.

I was able to modify two of the three `sed` invocations to work
cross-platform, but the third (and most complex) `sed` command
I could not get to work - so instead I replaced it with a small
node.js script which both copies the files and does the textual
modifications.

The script has no dependencies other than node.js, and given that
the build script requires typescript to be installed, presumably
the user will have node available.