### PR TITLE
Add target parameter to Vector and Rotation

### DIFF
--- a/src.ts/dynamics/joint.ts
+++ b/src.ts/dynamics/joint.ts
@@ -67,9 +67,10 @@ export class Joint {
     // #if DIM3
     /**
      * The rotation quaternion that aligns this joint's first local axis to the `x` axis.
+     * @param target - The target Rotation object to write to.
      */
-    public frameX1(): Rotation {
-        return RotationOps.fromRaw(this.rawSet.jointFrameX1(this.handle));
+    public frameX1(target?: Rotation): Rotation {
+        return RotationOps.fromRaw(this.rawSet.jointFrameX1(this.handle), target);
     }
 
     // #endif
@@ -77,9 +78,10 @@ export class Joint {
     // #if DIM3
     /**
      * The rotation matrix that aligns this joint's second local axis to the `x` axis.
+     * @param target - The target Rotation object to write to.
      */
-    public frameX2(): Rotation {
-        return RotationOps.fromRaw(this.rawSet.jointFrameX2(this.handle));
+    public frameX2(target?: Rotation): Rotation {
+        return RotationOps.fromRaw(this.rawSet.jointFrameX2(this.handle), target);
     }
 
     // #endif
@@ -89,9 +91,10 @@ export class Joint {
      *
      * The first anchor gives the position of the points application point on the
      * local frame of the first rigid-body it is attached to.
+     * @param target - The target Vector object to write to.
      */
-    public anchor1(): Vector {
-        return VectorOps.fromRaw(this.rawSet.jointAnchor1(this.handle));
+    public anchor1(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.jointAnchor1(this.handle), target);
     }
 
     /**
@@ -100,8 +103,8 @@ export class Joint {
      * The second anchor gives the position of the points application point on the
      * local frame of the second rigid-body it is attached to.
      */
-    public anchor2(): Vector {
-        return VectorOps.fromRaw(this.rawSet.jointAnchor2(this.handle));
+    public anchor2(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.jointAnchor2(this.handle), target);
     }
 
     /**
@@ -111,8 +114,8 @@ export class Joint {
      * this returns the application axis on the first rigid-body this joint is attached to, expressed
      * in the local-space of this first rigid-body.
      */
-    public axis1(): Vector {
-        return VectorOps.fromRaw(this.rawSet.jointAxis1(this.handle));
+    public axis1(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.jointAxis1(this.handle), target);
     }
 
     /**
@@ -122,8 +125,8 @@ export class Joint {
      * this returns the application axis on the second rigid-body this joint is attached to, expressed
      * in the local-space of this second rigid-body.
      */
-    public axis2(): Vector {
-        return VectorOps.fromRaw(this.rawSet.jointAxis2(this.handle))
+    public axis2(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.jointAxis2(this.handle), target)
     }
 
     /**

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -52,31 +52,69 @@ export class RigidBody {
 
     /**
      * The world-space translation of this rigid-body.
+     * @param target - The target Vector object to write to.
      */
-    public translation(): Vector {
+    public translation(target?: Vector): Vector {
         let res = this.rawSet.rbTranslation(this.handle);
-        return VectorOps.fromRaw(res);
+        return VectorOps.fromRaw(res, target);
     }
+
+    // #if DIM3
+
+    /**
+     * The world-space orientation of this rigid-body.
+     * @param target - The target Rotation object to write to.
+     */
+    public rotation(target?: Rotation): Rotation {
+        let res = this.rawSet.rbRotation(this.handle);
+        return RotationOps.fromRaw(res, target);
+    }
+
+    // #endif
+
+    // #if DIM2
 
     /**
      * The world-space orientation of this rigid-body.
      */
-    public rotation(): Rotation {
+     public rotation(): Rotation {
         let res = this.rawSet.rbRotation(this.handle);
         return RotationOps.fromRaw(res);
     }
 
+    // #endif
+
     /**
      * The world-space next translation of this rigid-body.
+     * @param target - The target Vector object to write to.
      *
      * If this rigid-body is kinematic this value is set by the `setNextKinematicTranslation`
      * method and is used for estimating the kinematic body velocity at the next timestep.
      * For non-kinematic bodies, this value is currently unspecified.
      */
-    public nextTranslation(): Vector {
+    public nextTranslation(target?: Vector): Vector {
         let res = this.rawSet.rbNextTranslation(this.handle);
-        return VectorOps.fromRaw(res);
+        return VectorOps.fromRaw(res, target);
     }
+
+    // #if DIM3
+
+    /**
+     * The world-space next orientation of this rigid-body.
+     * @param target - The target Rotation object to write to.
+     *
+     * If this rigid-body is kinematic this value is set by the `setNextKinematicRotation`
+     * method and is used for estimating the kinematic body velocity at the next timestep.
+     * For non-kinematic bodies, this value is currently unspecified.
+     */
+    public nextRotation(target?: Rotation): Rotation {
+        let res = this.rawSet.rbNextRotation(this.handle);
+        return RotationOps.fromRaw(res, target);
+    }
+
+    // #endif
+
+    // #if DIM2
 
     /**
      * The world-space next orientation of this rigid-body.
@@ -85,10 +123,12 @@ export class RigidBody {
      * method and is used for estimating the kinematic body velocity at the next timestep.
      * For non-kinematic bodies, this value is currently unspecified.
      */
-    public nextRotation(): Rotation {
+     public nextRotation(): Rotation {
         let res = this.rawSet.rbNextRotation(this.handle);
         return RotationOps.fromRaw(res);
     }
+
+    // #endif
 
     /**
      * Sets the translation of this rigid-body.
@@ -248,17 +288,19 @@ export class RigidBody {
 
     /**
      * The linear velocity of this rigid-body.
+     * @param target - The target Vector object to write to.
      */
-    public linvel(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbLinvel(this.handle));
+    public linvel(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbLinvel(this.handle), target);
     }
 
     // #if DIM3
     /**
      * The angular velocity of this rigid-body.
+     * @param target - The target Vector object to write to.
      */
-    public angvel(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbAngvel(this.handle));
+    public angvel(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbAngvel(this.handle), target);
     }
 
     // #endif

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -43,17 +43,32 @@ export class Collider {
 
     /**
      * The world-space translation of this rigid-body.
+     * @param target - The target Vector object to write to.
      */
-    public translation(): Vector {
-        return VectorOps.fromRaw(this.rawSet.coTranslation(this.handle));
+    public translation(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.coTranslation(this.handle), target);
     }
+
+    // #if DIM3
 
     /**
      * The world-space orientation of this rigid-body.
+     * @param target - The target Rotation object to write to.
      */
-    public rotation(): Rotation {
+    public rotation(target?: Rotation): Rotation {
+        return RotationOps.fromRaw(this.rawSet.coRotation(this.handle), target);
+    }
+
+    // #endif
+
+    // #if DIM2
+    /**
+     * The world-space orientation of this rigid-body.
+     */
+     public rotation(): Rotation {
         return RotationOps.fromRaw(this.rawSet.coRotation(this.handle));
     }
+    // #endif
 
     /**
      * Is this collider a sensor?
@@ -71,9 +86,10 @@ export class Collider {
 
     /**
      * The half-extents of this collider if it is a cuboid shape.
+     * @param target - The target Vector object to write to.
      */
-    public halfExtents(): Vector {
-        return VectorOps.fromRaw(this.rawSet.coHalfExtents(this.handle));
+    public halfExtents(target?: Vector): Vector {
+        return VectorOps.fromRaw(this.rawSet.coHalfExtents(this.handle), target);
     }
 
     /**
@@ -125,10 +141,11 @@ export class Collider {
     /**
      * If this collider has a heightfield shape, this returns the scale
      * applied to it.
+     * @param target - The target Vector object to write to.
      */
-    public heightfieldScale(): Vector {
+    public heightfieldScale(target?: Vector): Vector {
         let scale = this.rawSet.coHeightfieldScale(this.handle);
-        return VectorOps.fromRaw(scale);
+        return VectorOps.fromRaw(scale, target);
     }
 
     // #if DIM3

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -371,7 +371,7 @@ export class Polyline {
      */
     constructor(vertices: Float32Array, indices: Uint32Array) {
         this.vertices = vertices;
-        this.indices = !!indices ? indices : new Uint32Array();
+        this.indices = !!indices ? indices : new Uint32Array(0);
     }
 
     public intoRaw(): RawShape {

--- a/src.ts/math.ts
+++ b/src.ts/math.ts
@@ -29,11 +29,20 @@ export class VectorOps {
     }
 
     // FIXME: type ram: RawVector?
-    public static fromRaw(raw: RawVector): Vector {
+    public static fromRaw(raw: RawVector, target?: Vector): Vector {
         if (!raw)
             return null;
 
-        let res = VectorOps.new(raw.x, raw.y);
+        let res: Vector;
+
+        if (target) {
+            target.x = raw.x;
+            target.y = raw.y;
+            res = target;
+        } else {
+            res = VectorOps.new(raw.x, raw.y);
+        }
+
         raw.free();
         return res;
     }
@@ -106,11 +115,21 @@ export class VectorOps {
     }
 
     // FIXME: type ram: RawVector?
-    public static fromRaw(raw: RawVector): Vector {
+    public static fromRaw(raw: RawVector, target?: Vector): Vector {
         if (!raw)
             return null;
 
-        let res = VectorOps.new(raw.x, raw.y, raw.z);
+        let res: Vector;
+
+        if (target) {
+            target.x = raw.x;
+            target.y = raw.y;
+            target.z = raw.z;
+            res = target;
+        } else {
+            res = VectorOps.new(raw.x, raw.y, raw.z);
+        }
+
         raw.free();
         return res;
     }
@@ -145,11 +164,22 @@ export class RotationOps {
         return new Quaternion(0.0, 0.0, 0.0, 1.0);
     }
 
-    public static fromRaw(raw: RawRotation): Rotation {
+    public static fromRaw(raw: RawRotation, target?: Rotation): Rotation {
         if (!raw)
             return null;
 
-        let res = new Quaternion(raw.x, raw.y, raw.z, raw.w);
+        let res 
+
+        if (target) {
+            target.x = raw.x;
+            target.y = raw.y;
+            target.z = raw.z;
+            target.w = raw.w;
+            res = target;
+        } else {
+            res = new Quaternion(raw.x, raw.y, raw.z, raw.w);
+        }
+
         raw.free();
         return res;
     }


### PR DESCRIPTION
I noticed it's not possible to get the rotation/translation of a Collider without allocating a new `Vector` or `Rotation` object. Now you can provide an object that implements `Vector` or `Rotation` such as `THREE.Vector3` or `THREE.Quaternion` and those methods will write values from the RawVector/RawRotation to the provided objects.

Also, I was having some issues getting set up to build the libraries so I haven't been able to test this yet.

I have `wasm-pack` and `typedoc` installed and the latest version of Rust. I'd like to be able to build the compat versions of the library and link them into my project to test.