### PR TITLE
Separate generated JavaScript from TypeScript source.

### DIFF
--- a/rapier2d/build_typescript.sh
+++ b/rapier2d/build_typescript.sh
@@ -1,8 +1,10 @@
-cp -r ../src.ts/* pkg/.
+mkdir -p ./pkg/src
+cp -r ../src.ts/* pkg/src/.
+rm -f ./pkg/src/raw.ts
 echo 'export * from "./rapier_wasm2d"' > pkg/raw.ts
 # See https://serverfault.com/a/137848
 find pkg/ -type f -print0 | LC_ALL=C xargs -0 sed -i.bak '\:#if DIM3:,\:#endif:d'
-npx tsc
+npx tsc -p ./tsconfig.src.json
 # NOTE: we keep the typescripts files into the NPM package for source mapping: see #3
 sed -i.bak 's/"module": "rapier_wasm2d.js"/"module": "rapier.js"/g' pkg/package.json
 sed -i.bak 's/"types": "rapier_wasm2d.d.ts"/"types": "rapier.d.ts"/g' pkg/package.json

--- a/rapier2d/tsconfig.src.json
+++ b/rapier2d/tsconfig.src.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDirs": ["./pkg", "./pkg/src"]
+  },
+  "files": [
+    "./pkg/src/rapier.ts"
+  ]
+}

--- a/rapier3d/build_typescript.sh
+++ b/rapier3d/build_typescript.sh
@@ -1,8 +1,10 @@
-cp -r ../src.ts/* pkg/.
+mkdir -p ./pkg/src
+cp -r ../src.ts/* pkg/src/.
+rm -f ./pkg/src/raw.ts
 echo 'export * from "./rapier_wasm3d"' > pkg/raw.ts
 # See https://serverfault.com/a/137848
 find pkg/ -type f -print0 | LC_ALL=C xargs -0 sed -i.bak '\:#if DIM2:,\:#endif:d'
-npx tsc
+npx tsc -p ./tsconfig.src.json
 # NOTE: we keep the typescripts files into the NPM package for source mapping: see #3
 sed -i.bak 's/"module": "rapier_wasm3d.js"/"module": "rapier.js"/g' pkg/package.json
 sed -i.bak 's/"types": "rapier_wasm3d.d.ts"/"types": "rapier.d.ts"/g' pkg/package.json

--- a/rapier3d/tsconfig.src.json
+++ b/rapier3d/tsconfig.src.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDirs": ["./pkg", "./pkg/src"]
+  },
+  "files": [
+    "./pkg/src/rapier.ts"
+  ]
+}


### PR DESCRIPTION
Changes the typescript_build.sh script to copy the .ts
files into 'pkg/src' instead of 'pkg'. Adjusts the tsconfig.json
file so that it looks for sources in both 'pkg' and 'pkg/src'.

Verified that generated source maps point to the correct location.

In general, mixing .ts sources and generated .js and .d.ts in the
same directory can cause problems for downstream consumers of
the library. Some bundlers will preferentially load the .ts files
instead of the .js files, which will generate syntax errors if
the TypeScript compiler options for the main app are significantly
different than the compiler options for the library. By keeping
these files separate, better isolation is achieved.