### PR TITLE
Separate generated JavaScript from TypeScript source in rapier3d

### DIFF
--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -6,7 +6,7 @@
     "build-rust-2d": "cd ../rapier2d ; wasm-pack build --target web",
     "build-rust-3d": "cd ../rapier3d ; wasm-pack build --target web",
     "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
-    "build": "npm run clean && npm run build-rust && npx webpack",
+    "build": "npm run clean && npm run build-rust && npx webpack --env phase=1 && npx webpack --env phase=2",
     "clean": "npx rimraf ../rapier2d/pkg ../rapier3d/pkg pkg2d pkg3d ../rapier2d/docs ../rapier3d/docs",
     "all": "npm run build"
   },

--- a/rapier-compat/tsconfig.common.json
+++ b/rapier-compat/tsconfig.common.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "target": "es5",
+    "lib": [
+      "es5",
+      "DOM"
+    ],
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true
+  }
+}

--- a/rapier-compat/tsconfig.pkg2d.json
+++ b/rapier-compat/tsconfig.pkg2d.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "./pkg2d"
+  },
+  "files": [
+    "./pkg2d/rapier.ts"
+  ]
+}

--- a/rapier-compat/tsconfig.pkg3d.json
+++ b/rapier-compat/tsconfig.pkg3d.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "./pkg3d"
+  },
+  "files": [
+    "./pkg3d/rapier.ts"
+  ]
+}

--- a/rapier2d/build_typescript.sh
+++ b/rapier2d/build_typescript.sh
@@ -1,5 +1,7 @@
-cp -r ../src.ts/* pkg/.
-echo 'export * from "./rapier_wasm2d"' > pkg/raw.ts
+mkdir -p ./pkg/src
+cp -r ../src.ts/* pkg/src/.
+rm -f ./pkg/raw.ts
+echo 'export * from "./rapier_wasm2d"' > pkg/src/raw.ts
 # See https://serverfault.com/a/137848
 find pkg/ -type f -print0 | LC_ALL=C xargs -0 sed -i.bak '\:#if DIM3:,\:#endif:d'
 npx tsc

--- a/rapier2d/tsconfig.json
+++ b/rapier2d/tsconfig.json
@@ -8,9 +8,10 @@
     ],
     "moduleResolution": "node",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "rootDirs": ["./pkg", "./pkg/src"]
   },
   "files": [
-    "./pkg/rapier.ts"
+    "./pkg/src/rapier.ts"
   ]
 }

--- a/rapier3d/build_typescript.sh
+++ b/rapier3d/build_typescript.sh
@@ -1,5 +1,7 @@
-cp -r ../src.ts/* pkg/.
-echo 'export * from "./rapier_wasm3d"' > pkg/raw.ts
+mkdir -p ./pkg/src
+cp -r ../src.ts/* pkg/src/.
+rm -f ./pkg/raw.ts
+echo 'export * from "./rapier_wasm3d"' > pkg/src/raw.ts
 # See https://serverfault.com/a/137848
 find pkg/ -type f -print0 | LC_ALL=C xargs -0 sed -i.bak '\:#if DIM2:,\:#endif:d'
 npx tsc

--- a/rapier3d/tsconfig.json
+++ b/rapier3d/tsconfig.json
@@ -8,9 +8,10 @@
     ],
     "moduleResolution": "node",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "rootDirs": ["./pkg", "./pkg/src"]
   },
   "files": [
-    "./pkg/rapier.ts"
+    "./pkg/src/rapier.ts"
   ]
 }


### PR DESCRIPTION
and rapier2d packages. (rapier-compat package structure not changed.)

Changes the typescript_build.sh script to copy the .ts
files into 'pkg/src' instead of 'pkg'. Adjusts the tsconfig.json
file so that it looks for sources in both 'pkg' and 'pkg/src'.

Also isolate the rapier-compat build from the rapier3d and rapier2d
build directories. rapier-compat still includes build artifacts
from these other directories, but no longer overwrites any of the
files there.

Verified that generated source maps point to the correct location.

In general, mixing .ts sources and generated .js and .d.ts in the
same directory can cause problems for downstream consumers of
the library. Some bundlers will preferentially load the .ts files
instead of the .js files, which will generate syntax errors if
the TypeScript compiler options for the main app are significantly
different than the compiler options for the library. By keeping
these files separate, better isolation is achieved.