### PR TITLE
esmodule build

### DIFF
--- a/.github/workflows/rapier-js-ci-build.yml
+++ b/.github/workflows/rapier-js-ci-build.yml
@@ -29,6 +29,8 @@ jobs:
         run: cd rapier3d; ./build_all.sh;
       - name: Build rapier-compat
         run: npm install; cd rapier-compat; npm install; npm run build;
+      - name: Build rapier-module
+        run: cd rapier-module; npm install; npm run build;
   build-macos:
     runs-on: macos-latest
     env:
@@ -42,3 +44,5 @@ jobs:
         run: cd rapier3d; ./build_all.sh;
       - name: Build rapier-compat
         run: npm install; cd rapier-compat; npm install; npm run build;
+      - name: Build rapier-module
+        run: cd rapier-module; npm install; npm run build;

--- a/rapier-module/package.json
+++ b/rapier-module/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "build-rapier",
+  "description": "Build scripts targeting a buildless modern browser env.",
+  "private": true,
+  "scripts": {
+    "build-rust-2d": "wasm-pack build ../rapier2d --target web",
+    "build-rust-3d": "wasm-pack build ../rapier3d --target web",
+    "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
+    "build": "npm run clean && npm run build-rust && npm run webpack",
+    "clean": "npx rimraf ../rapier2d/pkg ../rapier3d/pkg pkg2d pkg3d ../rapier2d/docs ../rapier3d/docs",
+    "webpack": "npx webpack --env phase=src && npx webpack --env phase=compile",
+    "webpack-inline": "npx webpack --env phase=src && npx webpack --env phase=compileInlined",
+    "all": "npm run build"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^7.0.0",
+    "create-file-webpack": "^1.0.2",
+    "file-loader": "^6.2.0",
+    "rimraf": "^3.0.2",
+    "ts-loader": "^8.0.12",
+    "typescript": "^4.1.3",
+    "url-loader": "^4.1.1",
+    "webpack": "^5.11.0",
+    "webpack-cli": "^4.3.0",
+    "wrapper-webpack-plugin": "^2.1.0"
+  }
+}

--- a/rapier-module/package.json
+++ b/rapier-module/package.json
@@ -6,7 +6,7 @@
     "build-rust-2d": "wasm-pack build ../rapier2d --target web",
     "build-rust-3d": "wasm-pack build ../rapier3d --target web",
     "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
-    "build": "npm run clean && npm run build-rust && npm run webpack",
+    "build": "npm run clean && npm run build-rust && npm run webpack-inline",
     "clean": "npx rimraf ../rapier2d/pkg ../rapier3d/pkg pkg2d pkg3d ../rapier2d/docs ../rapier3d/docs",
     "webpack": "npx webpack --env phase=src && npx webpack --env phase=compile",
     "webpack-inline": "npx webpack --env phase=src && npx webpack --env phase=compileInlined",

--- a/rapier-module/tsconfig.json
+++ b/rapier-module/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2020",
+    "lib": [
+      "es2020",
+      "DOM"
+    ],
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "files": [
+    "./src/rapier.ts"
+  ]
+}

--- a/rapier-module/webpack.config.js
+++ b/rapier-module/webpack.config.js
@@ -1,0 +1,234 @@
+const CreateFileWebpack = require("create-file-webpack");
+const CopyPlugin = require("copy-webpack-plugin");
+const path = require("path");
+const WrapperPlugin = require('wrapper-webpack-plugin');
+
+function matchOtherDimRegex({is2d}) {
+    if (is2d) {
+        return /^ *\/\/ *#if +DIM3[\s\S]*?(?=#endif)#endif/gm;
+    } else {
+        return /^ *\/\/ *#if +DIM2[\s\S]*?(?=#endif)#endif/gm;
+    }
+}
+
+function initCode({is2d}) {
+    let dim = is2d ? "2d" : "3d";
+
+    return `
+import wasmInit from "./rapier_wasm${dim}";
+
+/**
+ * Initializes RAPIER.
+ * Has to be called and awaited before using any library methods.
+ */
+export async function init() {
+    await wasmInit();
+}`;
+}
+
+function copyAndReplace({is2d}) {
+    let dim = is2d ? "2d" : "3d";
+
+    return {
+        mode: "production",
+        entry: {},
+        plugins: [
+            new CopyPlugin({
+                patterns: [
+                    // copy src.ts into pkg for compiling,
+                    // remove sections wrapped in #ifdef DIMx ... #endif
+                    // add init() function to rapier.ts
+                    {
+                        from: path.resolve(__dirname, "../src.ts"),
+                        to: path.resolve(__dirname, `./pkg${dim}/src/`),
+                        transform(content, filepath) {
+                            let result = content
+                                .toString()
+                                .replace(matchOtherDimRegex({is2d}), "");
+
+                            if (filepath.endsWith(path.sep + "rapier.ts")) {
+                                result += initCode({is2d});
+                            }
+                            return result;
+                        },
+                        filter: (path) => !path.endsWith("raw.ts"),
+                    },
+                    {
+                        context: path.resolve(__dirname, `../rapier${dim}/pkg/`),
+                        from: 'rapier_wasm*',
+                        to: path.resolve(__dirname, `./pkg${dim}/src/`),
+                    },
+                    // copy package.json, adapting entries, LICENSE and README.md
+                    {
+                        from: path.resolve(__dirname, `../rapier${dim}/pkg/package.json`),
+                        to: path.resolve(__dirname, `./pkg${dim}/package.json`),
+                        transform(content) {
+                            let config = JSON.parse(content.toString());
+                            config.name = `@dimforge/rapier${dim}-module`;
+                            config.description += " esmodule for buildless use in modern browsers";
+                            config.types = "dist/rapier.d.ts";
+                            config.main = "dist/rapier.js";
+                            config.type = "module",
+                            config.files = ["*"];
+                            delete config.module;
+
+                            return JSON.stringify(config, undefined, 2);
+                        },
+                    },
+                    {
+                        from: path.resolve(__dirname, `../rapier${dim}/pkg/LICENSE`),
+                        to: path.resolve(__dirname, `./pkg${dim}`),
+                    },
+                    {
+                        from: path.resolve(__dirname, `../rapier${dim}/pkg/README.md`),
+                        to: path.resolve(__dirname, `./pkg${dim}/README.md`),
+                    },
+                    {
+                        from: path.resolve(__dirname, `./tsconfig.json`),
+                        to: path.resolve(__dirname, `./pkg${dim}/`),
+                    },
+                ],
+            }),
+            // ts files import from raw.ts, create the file reexporting the wasm-bindgen exports.
+            // the indirection simplifies switching between 2d and 3d
+            new CreateFileWebpack({
+                path: path.resolve(__dirname, `./pkg${dim}/src/`),
+                fileName: "raw.ts",
+                content: `export * from "./rapier_wasm${dim}.js"`,
+            })
+        ],
+    };
+}
+
+function compile({is2d}) {
+    let dim = is2d ? "2d" : "3d";
+
+    return {
+        mode: "production",
+        entry: `./pkg${dim}/src/rapier.ts`,
+        devtool: "source-map",
+        module: {
+            rules: [
+                {
+                    test: /\.wasm$/,
+                    type: 'asset/resource',
+                    generator: {
+                        filename: 'rapier.wasm'
+                     }
+                },
+                {
+                    test: /\.tsx?$/,
+                    loader: "ts-loader",
+                    exclude: /node_modules/
+                },
+            ],
+        },
+        plugins: [
+            new WrapperPlugin({
+                test: /rapier\.js$/,
+                header: "",
+                footer: 'await __webpack_exports__init();' // wait for the wasm to load before resolving the module
+            })
+        ],
+        resolve: {
+            extensions: [".tsx", ".ts", ".js"],
+        },
+        output: {
+            filename: "rapier.js",
+            path: path.resolve(__dirname, `pkg${dim}`, 'dist'),
+            library: {
+                type: "module"
+            }
+        },
+        optimization: {
+            minimize: true
+        },
+        experiments:{
+            asyncWebAssembly: true,
+            outputModule: true,
+            topLevelAwait: true,
+        }
+    };
+}
+
+function compileInlined({is2d}) {
+    let dim = is2d ? "2d" : "3d";
+
+    return {
+        mode: "production",
+        entry: `./pkg${dim}/src/rapier.ts`,
+        devtool: "source-map",
+        module: {
+            rules: [
+                {
+                    test: /\.wasm$/,
+                    type: 'asset/inline'
+                },
+                {
+                    test: /\.tsx?$/,
+                    loader: "ts-loader",
+                    exclude: /node_modules/
+                }
+            ]
+        },
+        plugins: [
+            new WrapperPlugin({
+                test: /rapier\.js$/,
+                header: "",
+                footer: 'await __webpack_exports__init();' // wait for the wasm to load before resolving the module
+            })
+        ],
+        resolve: {
+            extensions: [".tsx", ".ts", ".js"],
+        },
+        output: {
+            filename: "rapier.js",
+            enabledChunkLoadingTypes: ["import-scripts"],
+            chunkLoading: "import-scripts",
+            wasmLoading: "fetch",
+            path: path.resolve(__dirname, `pkg${dim}`, 'dist'),
+            library: {
+                type: "module"
+            }
+        },
+        optimization: {
+            minimize: true
+        },
+        experiments:{
+            asyncWebAssembly: true,
+            outputModule: true,
+            topLevelAwait: true,
+        }
+    };
+}
+
+// Webpack doesn't really handle files that are both inputs and outputs. Instead, run
+// webpack twice, once to genrate the source, and once to compile it.
+module.exports = env => {
+    switch(env.phase){
+        case 'src':
+            return [
+                // 2d
+                copyAndReplace({is2d: true}),
+
+                // 3d
+                copyAndReplace({is2d: false}),
+            ]
+        case 'compile':
+            return [
+                // 2d
+                compile({is2d: true}),
+
+                // 3d
+                compile({is2d: false})
+            ]
+        case 'compileInlined':
+            return [
+                // 2d
+                compileInlined({is2d: true}),
+
+                // 3d
+                compileInlined({is2d: false})
+            ]
+    }
+}


### PR DESCRIPTION
This PR adds an extra build of Rapier that is intended to fulfil the following:
* Provide an esmodule import of Rapier that works in a buildless project on modern browsers
* Remove the need to call `RAPIER.init()` or follow the `import().then()` pattern
* Works in webworkers (the current rapier-compat fails)
* Clean up the distributed library a bit:
  * Have type files/source maps generated correctly
  * export the typescript source, but keep it separate to the 'dist' code

**Usage:**
Once built it's pretty simple:
```html
<script type="module">
	import * as RAPIER from "./pkg2d/dist/rapier.js";
	let world = new RAPIER.World();
	console.log(world);
</script>
```
Served from a webserver this will work as expected; no `init` or `then` call required.

**Drawbacks:**
* This build uses the same workaround as rapier-compat to get around some wasm-pack/webpack 5 limitations, so the wasm is bundled inline as base64, inflating the file size somewhat. **FIXED - there is now an option of compile steps; one with inlining one without**
* There are two required dist files rather than one; I couldn't get webpack to bundle rapier.js and rapier_async.js without it breaking the async nature of the module; I'm sure if I was more of a webpack guru I'd be able to. **Fixed - back down to one dist file by appending the top level await that bootstrap was mangling after compilation**

**Distribution**
The intension would be to ship the whole pkg2d or pkg3d as a new npm package `rapier*-module`; I've move the package.json files etc in the build to facilitate this.

**Disclaimer**
I'm pretty dreadful at getting webpack to do what I want, so there is the very real probability that this is a overly convoluted way to achieve the desired result!

No worries if this isn't something you want to pull into the main repo; I know not everybody needs/wants a buildless version of libraries - particularly when the web features being targeted are very new!
