### PR TITLE
Add missing bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,56 @@
 ### v0.7.0
+The typescripts bindings for Rapier have a [brand new user-guide](https://rapier.rs/docs/user_guides/javascript/getting_started_js)
+covering all the features of the physics engine!
+
+### Breaking change
 - The `World.castRay` and `World.castRayAndGetNormal` methods have a different signature now, making them
   more flexible.
+- Rename `ActiveHooks::FILTER_CONTACT_PAIR` to `ActiveHooks.FILTER_CONTACT_PAIRS`.
+- Rename `ActiveHooks::FILTER_INTERSECTION_PAIR` to `ActiveHooks.FILTER_INTERSECTION_PAIRS`.
+- Rename `BodyStatus` to `RigidBodyType`.  
+- Rename `RigidBody.bodyStatus()` to `RigidBody.bodyType()`.
+- Rename `RigidBodyDesc.setMassProperties` to `RigidBodyDesc.setAdditionalMassProperties`.
+- Rename `RigidBodyDesc.setPrincipalAngularInertia` to `RigidBodyDesc.setAdditionalPrincipalAngularInertia`.
+- Rename `ColliderDesc.setIsSensor` to `ColliderDesc.setSensor.
+
+### Added
+- Add `Ray.pointAt(t)` that conveniently computes `ray.origin + ray.dir * t`.
+- Add access to joint motors by defining each joint with its own class deriving from `Joint`. Each joint now
+  have its relevant motor configuration methods: `configurMotorModel, configureMotorVelocity, configureMotorPosition, configureMotor`.
+- Add `World.collidersWithAabbIntersectingAabb` for retrieving the handles of all the colliders intersecting the given AABB.  
+- Add many missing methods for reading/modifying a rigid-body state after its creation:
+  * `RigidBody.lockTranslations`
+  * `RigidBody.lockRotations`
+  * `RigidBody.restrictRotations`
+  * `RigidBody.dominanceGroup`
+  * `RigidBody.setDominanceGroup`
+  * `RigidBody.enableCcd`
+- Add `RigidBodyDesc.setDominanceGroup` for setting the dominance group of the rigid-body being built.  
+- Add many missing methods for reading/modifying a collider state after its creation:
+  * `Collider.setSendor`
+  * `Collider.setShape`
+  * `Collider.setRestitution`
+  * `Collider.setFriction`
+  * `Collider.frictionCombineRule`
+  * `Collider.setFrictionCombineRule`
+  * `Collider.restitutionCombineRule`
+  * `Collider.setRestitutionCombineRule`
+  * `Collider.setCollisionGroups`
+  * `Collider.setSolverGroups`
+  * `Collider.activeHooks`
+  * `Collider.setActiveHooks`
+  * `Collider.activeEvents`
+  * `Collider.setActiveEvents`
+  * `Collider.activeCollisionTypes`
+  * `Collider.setTranslation`
+  * `Collider.setTranslationWrtParent`
+  * `Collider.setRotation`
+  * `Collider.setRotationWrtParent`
+- Add `ColliderDesc.setMassProperties` for setting explicitly the mass properties of the collider being built (instead of relying on density).
+
+### Modified
+- Colliders are no longer required to be attached to a rigid-body. Therefore, the second argument of `World.createCollider`
+  is now optional.
 
 ### v0.6.0
 #### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.7.0
+- The `World.castRay` and `World.castRayAndGetNormal` methods have a different signature now, making them
+  more flexible.
+
 ### v0.6.0
 #### Breaking changes
 - The `BodyStatus::Kinematic` variant has been replaced by `BodyStatus::KinematicPositionBased` and

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier2d" # Can't be named rapier2d which conflicts with the dependency.
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust - official JS bindings."
 documentation = "http://rapier.rs/rustdoc/rapier2d/index.html"
@@ -23,11 +23,11 @@ required-features = ["dim2"]
 
 
 [dependencies]
-rapier2d = { version = "^0.9", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism"] }
+rapier2d = { version = "^0.10.1", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism"] }
 ref-cast = "1"
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-nalgebra = "0.27"
+nalgebra = "0.28"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
 crossbeam-channel = "0.4"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier3d" # Can't be named rapier3d which conflicts with the dependency.
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust - official JS bindings."
 documentation = "http://rapier.rs/rustdoc/rapier2d/index.html"
@@ -23,11 +23,11 @@ required-features = ["dim3"]
 
 
 [dependencies]
-rapier3d = { version = "^0.9", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism"] }
+rapier3d = { version = "^0.10.1", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism"] }
 ref-cast = "1"
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-nalgebra = "0.27"
+nalgebra = "0.28"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
 crossbeam-channel = "0.4"

--- a/src.ts/dynamics/joint_set.ts
+++ b/src.ts/dynamics/joint_set.ts
@@ -1,6 +1,17 @@
 import {RawJointSet} from "../raw"
 import {RigidBodySet} from "./rigid_body_set";
-import {Joint, JointHandle, JointParams} from "./joint";
+import {
+    BallJoint,
+    FixedJoint,
+    Joint,
+    JointHandle,
+    JointParams,
+    JointType,
+    PrismaticJoint,
+    // #if DIM3
+    RevoluteJoint
+    // #endif
+} from "./joint";
 import {RigidBody, RigidBodyHandle} from "./rigid_body";
 import {IslandManager} from "./island_manager";
 
@@ -83,7 +94,18 @@ export class JointSet {
      */
     public get(handle: JointHandle): Joint {
         if (this.raw.contains(handle)) {
-            return new Joint(this.raw, handle);
+            switch (this.raw.jointType(handle)) {
+                case JointType.Ball:
+                    return new BallJoint(this.raw, handle);
+                case JointType.Prismatic:
+                    return new PrismaticJoint(this.raw, handle);
+                case JointType.Fixed:
+                    return new FixedJoint(this.raw, handle);
+                // #if DIM3
+                case JointType.Revolute:
+                    return new RevoluteJoint(this.raw, handle);
+                // #endif
+            }
         } else {
             return null;
         }

--- a/src.ts/dynamics/rigid_body_set.ts
+++ b/src.ts/dynamics/rigid_body_set.ts
@@ -69,6 +69,7 @@ export class RigidBodySet {
             desc.status,
             desc.canSleep,
             desc.ccdEnabled,
+            desc.dominanceGroup,
         );
 
         rawTra.free();

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -95,6 +95,228 @@ export class Collider {
         return this.rawSet.coIsSensor(this.handle);
     }
 
+    public setSensor(isSensor: boolean) {
+        this.rawSet.coSetSensor(this.handle, isSensor);
+    }
+
+    public setShape(shape: Shape) {
+        let rawShape = shape.intoRaw();
+        this.rawSet.coSetShape(this.handle, rawShape);
+        rawShape.free();
+    }
+
+    /**
+     * Sets the restitution coefficient of the collider to be created.
+     *
+     * @param restitution - The restitution coefficient in `[0, 1]`. A value of 0 (the default) means no bouncing behavior
+     *                   while 1 means perfect bouncing (though energy may still be lost due to numerical errors of the
+     *                   constraints solver).
+     */
+    public setRestitution(restitution: number) {
+        this.rawSet.coSetRestitution(this.handle, restitution);
+    }
+
+    /**
+     * Sets the friction coefficient of the collider to be created.
+     *
+     * @param friction - The friction coefficient. Must be greater or equal to 0. This is generally smaller than 1. The
+     *                   higher the coefficient, the stronger friction forces will be for contacts with the collider
+     *                   being built.
+     */
+    public setFriction(friction: number) {
+        this.rawSet.coSetFriction(this.handle, friction);
+    }
+
+    /**
+     * Gets the rule used to combine the friction coefficients of two colliders
+     * colliders involved in a contact.
+     */
+    public frictionCombineRule(): CoefficientCombineRule {
+        return this.rawSet.coFrictionCombineRule(this.handle);
+    }
+
+    /**
+     * Sets the rule used to combine the friction coefficients of two colliders
+     * colliders involved in a contact.
+     *
+     * @param rule − The combine rule to apply.
+     */
+    public setFrictionCombineRule(rule: CoefficientCombineRule) {
+        this.rawSet.coSetFrictionCombineRule(this.handle, rule);
+    }
+
+    /**
+     * Gets the rule used to combine the restitution coefficients of two colliders
+     * colliders involved in a contact.
+     */
+    public restitutionCombineRule(): CoefficientCombineRule {
+        return this.rawSet.coRestitutionCombineRule(this.handle);
+    }
+
+    /**
+     * Sets the rule used to combine the restitution coefficients of two colliders
+     * colliders involved in a contact.
+     *
+     * @param rule − The combine rule to apply.
+     */
+    public setRestitutionCombineRule(rule: CoefficientCombineRule) {
+        this.rawSet.coSetRestitutionCombineRule(this.handle, rule);
+    }
+
+    /**
+     * Sets the collision groups used by this collider.
+     *
+     * Two colliders will interact iff. their collision groups are compatible.
+     * See the documentation of `InteractionGroups` for details on teh used bit pattern.
+     *
+     * @param groups - The collision groups used for the collider being built.
+     */
+    public setCollisionGroups(groups: InteractionGroups) {
+        this.rawSet.coSetCollisionGroups(this.handle, groups);
+    }
+
+    /**
+     * Sets the solver groups used by this collider.
+     *
+     * Forces between two colliders in contact will be computed iff their solver
+     * groups are compatible.
+     * See the documentation of `InteractionGroups` for details on the used bit pattern.
+     *
+     * @param groups - The solver groups used for the collider being built.
+     */
+    public setSolverGroups(groups: InteractionGroups) {
+        this.rawSet.coSetSolverGroups(this.handle, groups);
+    }
+
+    /**
+     * Get the physics hooks active for this collider.
+     */
+    public activeHooks() {
+        this.rawSet.coActiveHooks(this.handle);
+    }
+
+    /**
+     * Set the physics hooks active for this collider.
+     *
+     * Use this to enable custom filtering rules for contact/intersecstion pairs involving this collider.
+     *
+     * @param activeHooks - The hooks active for contact/intersection pairs involving this collider.
+     */
+    public setActiveHooks(activeHooks: ActiveHooks) {
+        this.rawSet.coSetActiveHooks(this.handle, activeHooks);
+    }
+
+    /**
+     * The events active for this collider.
+     */
+    public activeEvents(): ActiveEvents {
+        return this.rawSet.coActiveEvents(this.handle);
+    }
+
+    /**
+     * Set the events active for this collider.
+     *
+     * Use this to enable contact and/or intersection event reporting for this collider.
+     *
+     * @param activeEvents - The events active for contact/intersection pairs involving this collider.
+     */
+    public setActiveEvents(activeEvents: ActiveEvents) {
+        this.rawSet.coSetActiveEvents(this.handle, activeEvents);
+    }
+
+    /**
+     * Gets the collision types active for this collider.
+     */
+    public activeCollisionTypes(): ActiveCollisionTypes {
+        return this.rawSet.coActiveCollisionTypes(this.handle);
+    }
+
+    /**
+     * Set the collision types active for this collider.
+     *
+     * @param activeCollisionTypes - The hooks active for contact/intersection pairs involving this collider.
+     */
+    public setActiveCollisionTypes(activeCollisionTypes: ActiveCollisionTypes) {
+        this.rawSet.coSetActiveCollisionTypes(this.handle, activeCollisionTypes);
+    }
+
+    /**
+     * Sets the translation of this collider.
+     *
+     * @param tra - The world-space position of the collider.
+     */
+    public setTranslation(tra: Vector) {
+        // #if DIM2
+        this.rawSet.coSetTranslation(this.handle, tra.x, tra.y);
+        // #endif
+        // #if DIM3
+        this.rawSet.coSetTranslation(this.handle, tra.x, tra.y, tra.z);
+        // #endif
+    }
+
+    /**
+     * Sets the translation of this collider relative to its parent rigid-body.
+     *
+     * Does nothing if this collider isn't attached to a rigid-body.
+     *
+     * @param tra - The new translation of the collider relative to its parent.
+     */
+    public setTranslationWrtParent(tra: Vector) {
+        // #if DIM2
+        this.rawSet.coSetTranslationWrtParent(this.handle, tra.x, tra.y);
+        // #endif
+        // #if DIM3
+        this.rawSet.coSetTranslationWrtParent(this.handle, tra.x, tra.y, tra.z);
+        // #endif
+    }
+
+    // #if DIM3
+    /**
+     * Sets the rotation quaternion of this collider.
+     *
+     * This does nothing if a zero quaternion is provided.
+     *
+     * @param rotation - The rotation to set.
+     */
+    public setRotation(rot: Rotation) {
+        this.rawSet.coSetRotation(this.handle, rot.x, rot.y, rot.z, rot.w);
+    }
+
+
+    /**
+     * Sets the rotation quaternion of this collider relative to its parent rigid-body.
+     *
+     * This does nothing if a zero quaternion is provided or if this collider isn't
+     * attached to a rigid-body.
+     *
+     * @param rotation - The rotation to set.
+     */
+    public setRotationWrtParent(rot: Rotation) {
+        this.rawSet.coSetRotationWrtParent(this.handle, rot.x, rot.y, rot.z, rot.w);
+    }
+    // #endif
+    // #if DIM2
+    /**
+     * Sets the rotation angle of this collider.
+     *
+     * @param angle - The rotation angle, in radians.
+     */
+    public setRotation(angle: number) {
+        this.rawSet.coSetRotation(this.handle, angle);
+    }
+
+    /**
+     * Sets the rotation angle of this collider relative to its parent rigid-body.
+     *
+     * Does nothing if this collider isn't attached to a rigid-body.
+     *
+     * @param angle - The rotation angle, in radians.
+     */
+    public setRotationWrtParent(angle: number) {
+        this.rawSet.coSetRotationWrtParent(this.handle, angle);
+    }
+    // #endif
+
     /**
      * The type of the shape of this collider.
      */
@@ -212,21 +434,28 @@ export class Collider {
     }
 
     /**
-     * The solver gorups of this collider.
+     * The solver groups of this collider.
      */
     public solverGroups(): InteractionGroups {
         return this.rawSet.coSolverGroups(this.handle);
-    }
-
-    public activeHooks(): ActiveHooks {
-        return this.rawSet.coActiveHooks(this.handle);
     }
 }
 
 
 export class ColliderDesc {
     shape: Shape;
-    density?: number;
+    useMassProps: boolean;
+    mass: number;
+    centerOfMass: Vector;
+    // #if DIM2
+    principalAngularInertia: number;
+    rotationsEnabled: boolean;
+    // #endif
+    // #if DIM3
+    principalAngularInertia: Vector;
+    angularInertiaLocalFrame: Rotation;
+    // #endif
+    density: number;
     friction: number;
     restitution: number;
     rotation: Rotation;
@@ -247,7 +476,8 @@ export class ColliderDesc {
      */
     constructor(shape: Shape) {
         this.shape = shape;
-        this.density = null;
+        this.useMassProps = false;
+        this.density = 1.0;
         this.friction = 0.5;
         this.restitution = 0.0;
         this.rotation = RotationOps.identity();
@@ -260,6 +490,16 @@ export class ColliderDesc {
         this.activeCollisionTypes = ActiveCollisionTypes.DEFAULT;
         this.activeEvents = 0;
         this.activeHooks = 0;
+        this.mass = 0.0;
+        this.centerOfMass = VectorOps.zeros();
+        // #if DIM2
+        this.principalAngularInertia = 0.0;
+        this.rotationsEnabled = true;
+        // #endif
+        // #if DIM3
+        this.principalAngularInertia = VectorOps.zeros();
+        this.angularInertiaLocalFrame = RotationOps.identity();
+        // #endif
     }
 
     /**
@@ -609,7 +849,7 @@ export class ColliderDesc {
      *
      * @param is - Set to `true` of the collider built is to be a sensor.
      */
-    public setIsSensor(is: boolean): ColliderDesc {
+    public setSensor(is: boolean): ColliderDesc {
         this.isSensor = is;
         return this;
     }
@@ -621,9 +861,54 @@ export class ColliderDesc {
      *                  will not affect the mass or angular inertia of the rigid-body it is attached to.
      */
     public setDensity(density: number): ColliderDesc {
+        this.useMassProps = false;
         this.density = density;
         return this;
     }
+
+    // #if DIM2
+    /**
+     * Sets the mass properties of the collider being built.
+     *
+     * This replaces the mass-properties automatically computed from the collider's density and shape.
+     * These mass-properties will be added to the mass-properties of the rigid-body this collider will be attached to.
+     *
+     * @param mass − The mass of the collider to create.
+     * @param centerOfMass − The center-of-mass of the collider to create.
+     * @param principalAngularInertia − The principal angular inertia of the collider to create.
+     */
+    public setMassProperties(mass: number, centerOfMass: Vector, principalAngularInertia: number): ColliderDesc {
+        this.useMassProps = true;
+        this.mass = mass;
+        this.centerOfMass = centerOfMass;
+        this.principalAngularInertia = principalAngularInertia;
+        return this;
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * Sets the mass properties of the collider being built.
+     *
+     * This replaces the mass-properties automatically computed from the collider's density and shape.
+     * These mass-properties will be added to the mass-properties of the rigid-body this collider will be attached to.
+     *
+     * @param mass − The mass of the collider to create.
+     * @param centerOfMass − The center-of-mass of the collider to create.
+     * @param principalAngularInertia − The initial principal angular inertia of the collider to create.
+     *                                  These are the eigenvalues of the angular inertia matrix.
+     * @param angularInertiaLocalFrame − The initial local angular inertia frame of the collider to create.
+     *                                   These are the eigenvectors of the angular inertia matrix.
+     */
+    public setAdditionalMassProperties(mass: number, centerOfMass: Vector, principalAngularInertia: Vector, angularInertiaLocalFrame: Rotation): ColliderDesc {
+        this.useMassProps = true;
+        this.mass = mass;
+        this.centerOfMass = centerOfMass;
+        this.principalAngularInertia = principalAngularInertia;
+        this.angularInertiaLocalFrame = angularInertiaLocalFrame;
+        return this;
+    }
+    // #endif
 
     /**
      * Sets the restitution coefficient of the collider to be created.

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -900,7 +900,7 @@ export class ColliderDesc {
      * @param angularInertiaLocalFrame − The initial local angular inertia frame of the collider to create.
      *                                   These are the eigenvectors of the angular inertia matrix.
      */
-    public setAdditionalMassProperties(mass: number, centerOfMass: Vector, principalAngularInertia: Vector, angularInertiaLocalFrame: Rotation): ColliderDesc {
+    public setMassProperties(mass: number, centerOfMass: Vector, principalAngularInertia: Vector, angularInertiaLocalFrame: Rotation): ColliderDesc {
         this.useMassProps = true;
         this.mass = mass;
         this.centerOfMass = centerOfMass;

--- a/src.ts/geometry/ray.ts
+++ b/src.ts/geometry/ray.ts
@@ -9,11 +9,11 @@ export class Ray {
     /**
      * The starting point of the ray.
      */
-    origin: Vector
+    public origin: Vector
     /**
      * The direction of propagation of the ray.
      */
-    dir: Vector
+    public dir: Vector
 
     /**
      * Builds a ray from its origin and direction.
@@ -25,6 +25,16 @@ export class Ray {
         this.origin = origin;
         this.dir = dir;
     }
+
+    public pointAt(t: number): Vector {
+        return {
+            x: this.origin.x + this.dir.x * t,
+            y: this.origin.y + this.dir.y * t,
+            // #if DIM3
+            z: this.origin.z + this.dir.z * t,
+            // #endif
+        }
+    };
 }
 
 /**

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -2,8 +2,8 @@ import {RigidBodyHandle} from "../dynamics";
 import {ColliderHandle} from "../geometry";
 
 export enum ActiveHooks {
-    FILTER_CONTACT_PAIR = 0b0001,
-    FILTER_INTERSECTION_PAIR = 0b0010,
+    FILTER_CONTACT_PAIRS = 0b0001,
+    FILTER_INTERSECTION_PAIRS = 0b0010,
     // MODIFY_SOLVER_CONTACTS = 0b0100, /* Not supported yet in JS. */
 }
 

--- a/src.ts/pipeline/physics_pipeline.ts
+++ b/src.ts/pipeline/physics_pipeline.ts
@@ -64,48 +64,4 @@ export class PhysicsPipeline {
 
         rawG.free();
     }
-
-
-    /**
-     * Removes a rigid-body, and everything attached to it, from the given sets.
-     * @param handle - The handle of the rigid-body to remove.
-     * @param bodies - The set containing the rigid-body to remove.
-     * @param colliders - The set containing the colliders attached to the rigid-body to remove.
-     * @param joints - The set containing the joints attached to the rigid-body to remove.
-     */
-    public removeRigidBody(
-        handle: RigidBodyHandle,
-        islands: IslandManager,
-        bodies: RigidBodySet,
-        colliders: ColliderSet,
-        joints: JointSet,
-    ) {
-        this.raw.removeRigidBody(
-            handle,
-            islands.raw,
-            bodies.raw,
-            colliders.raw,
-            joints.raw
-        );
-    }
-
-    /**
-     * Remove a collider.
-     * @param handle - The handle of the collider to remove.
-     * @param bodies - The set of rigid-bodies containing the parent of the collider to remove.
-     * @param colliders - The set of colliders containing the collider to remove.
-     */
-    public removeCollider(
-        handle: ColliderHandle,
-        islands: IslandManager,
-        bodies: RigidBodySet,
-        colliders: ColliderSet,
-    ) {
-        this.raw.removeCollider(
-            handle,
-            islands.raw,
-            bodies.raw,
-            colliders.raw,
-        );
-    }
 }

--- a/src.ts/pipeline/query_pipeline.ts
+++ b/src.ts/pipeline/query_pipeline.ts
@@ -335,4 +335,24 @@ export class QueryPipeline {
         rawRot.free();
         rawShape.free();
     }
+
+    /**
+     * Finds the handles of all the colliders with an AABB intersecting the given AABB.
+     *
+     * @param aabbCenter - The center of the AABB to test.
+     * @param aabbHalfExtents - The half-extents of the AABB to test.
+     * @param callback - The callback that will be called with the handles of all the colliders
+     *                   currently intersecting the given AABB.
+     */
+    public collidersWithAabbIntersectingAabb(
+        aabbCenter: Vector,
+        aabbHalfExtents: Vector,
+        callback: (handle: ColliderHandle) => boolean,
+    ) {
+        let rawCenter = VectorOps.intoRaw(aabbCenter);
+        let rawHalfExtents = VectorOps.intoRaw(aabbHalfExtents);
+        this.raw.collidersWithAabbIntersectingAabb(rawCenter, rawHalfExtents, callback);
+        rawCenter.free();
+        rawHalfExtents.free();
+    }
 }

--- a/src/dynamics/joint_set.rs
+++ b/src/dynamics/joint_set.rs
@@ -13,6 +13,14 @@ impl RawJointSet {
             .expect("Invalid Joint reference. It may have been removed from the physics World.");
         f(body)
     }
+
+    pub(crate) fn map_mut<T>(&mut self, handle: u32, f: impl FnOnce(&mut Joint) -> T) -> T {
+        let (body, _) = self
+            .0
+            .get_unknown_gen_mut(handle)
+            .expect("Invalid Joint reference. It may have been removed from the physics World.");
+        f(body)
+    }
 }
 
 #[wasm_bindgen]

--- a/src/dynamics/joint_set.rs
+++ b/src/dynamics/joint_set.rs
@@ -42,7 +42,7 @@ impl RawJointSet {
         let parent2 = bodies.0.get_unknown_gen(parent2).unwrap().1;
 
         self.0
-            .insert(&mut bodies.0, parent1, parent2, params.0.clone())
+            .insert(parent1, parent2, params.0.clone())
             .into_raw_parts()
             .0
     }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -223,6 +223,40 @@ impl RawRigidBodySet {
         self.map(handle, |rb| RawVector(*rb.angvel()))
     }
 
+    pub fn rbLockTranslations(&mut self, handle: u32, locked: bool, wake_up: bool) {
+        self.map_mut(handle, |rb| rb.lock_translations(locked, wake_up))
+    }
+
+    pub fn rbLockRotations(&mut self, handle: u32, locked: bool, wake_up: bool) {
+        self.map_mut(handle, |rb| rb.lock_translations(locked, wake_up))
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn rbRestrictRotations(
+        &mut self,
+        handle: u32,
+        allow_x: bool,
+        allow_y: bool,
+        allow_z: bool,
+        wake_up: bool,
+    ) {
+        self.map_mut(handle, |rb| {
+            rb.restrict_rotations(allow_x, allow_y, allow_z, wake_up)
+        })
+    }
+
+    pub fn rbDominanceGroup(&self, handle: u32) -> i8 {
+        self.map(handle, |rb| rb.dominance_group())
+    }
+
+    pub fn rbSetDominanceGroup(&mut self, handle: u32, group: i8) {
+        self.map_mut(handle, |rb| rb.set_dominance_group(group))
+    }
+
+    pub fn rbEnableCcd(&mut self, handle: u32, enabled: bool) {
+        self.map_mut(handle, |rb| rb.enable_ccd(enabled))
+    }
+
     /// The mass of this rigid-body.
     pub fn rbMass(&self, handle: u32) -> f32 {
         self.map(handle, |rb| rb.mass())
@@ -259,7 +293,7 @@ impl RawRigidBodySet {
     }
 
     /// The status of this rigid-body: static, dynamic, or kinematic.
-    pub fn rbBodyStatus(&self, handle: u32) -> RawRigidBodyType {
+    pub fn rbBodyType(&self, handle: u32) -> RawRigidBodyType {
         self.map(handle, |rb| rb.body_type().into())
     }
 

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -81,6 +81,7 @@ impl RawRigidBodySet {
         rb_type: RawRigidBodyType,
         canSleep: bool,
         ccdEnabled: bool,
+        dominanceGroup: i8,
     ) -> u32 {
         let pos = na::Isometry3::from_parts(translation.0.into(), rotation.0);
         let props = MassProperties::with_principal_inertia_frame(
@@ -102,7 +103,8 @@ impl RawRigidBodySet {
             .linear_damping(linearDamping)
             .angular_damping(angularDamping)
             .can_sleep(canSleep)
-            .ccd_enabled(ccdEnabled);
+            .ccd_enabled(ccdEnabled)
+            .dominance_group(dominanceGroup);
         if !translationsEnabled {
             rigid_body = rigid_body.lock_translations();
         }
@@ -128,6 +130,7 @@ impl RawRigidBodySet {
         rb_type: RawRigidBodyType,
         canSleep: bool,
         ccdEnabled: bool,
+        dominanceGroup: i8,
     ) -> u32 {
         let pos = na::Isometry2::from_parts(translation.0.into(), rotation.0);
         let props = MassProperties::new(centerOfMass.0.into(), mass, principalAngularInertia);
@@ -142,13 +145,16 @@ impl RawRigidBodySet {
             .linear_damping(linearDamping)
             .angular_damping(angularDamping)
             .can_sleep(canSleep)
-            .ccd_enabled(ccdEnabled);
+            .ccd_enabled(ccdEnabled)
+            .dominance_group(dominanceGroup);
+
         if !transationsEnabled {
             rigid_body = rigid_body.lock_translations();
         }
         if !rotationsEnabled {
             rigid_body = rigid_body.lock_rotations();
         }
+
         self.0.insert(rigid_body.build()).into_raw_parts().0
     }
 

--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -18,6 +18,7 @@ mod ray;
 mod shape;
 mod toi;
 
+use rapier::dynamics::CoefficientCombineRule;
 use rapier::geometry::InteractionGroups;
 
 pub const fn unpack_interaction_groups(memberships_filter: u32) -> InteractionGroups {
@@ -29,4 +30,16 @@ pub const fn unpack_interaction_groups(memberships_filter: u32) -> InteractionGr
 
 pub const fn pack_interaction_groups(groups: InteractionGroups) -> u32 {
     (groups.memberships << 16) | groups.filter
+}
+
+pub const fn combine_rule_from_u32(rule: u32) -> CoefficientCombineRule {
+    if rule == CoefficientCombineRule::Average as u32 {
+        CoefficientCombineRule::Average
+    } else if rule == CoefficientCombineRule::Min as u32 {
+        CoefficientCombineRule::Min
+    } else if rule == CoefficientCombineRule::Multiply as u32 {
+        CoefficientCombineRule::Multiply
+    } else {
+        CoefficientCombineRule::Max
+    }
 }

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -84,37 +84,4 @@ impl RawPhysicsPipeline {
             &eventQueue.collector,
         );
     }
-
-    // TODO: BREAKING, remove this, and add the corresponding remove/maintain method to the sets
-    // and narrow/broad phases.
-    pub fn removeRigidBody(
-        &mut self,
-        handle: u32,
-        islands: &mut RawIslandManager,
-        bodies: &mut RawRigidBodySet,
-        colliders: &mut RawColliderSet,
-        joints: &mut RawJointSet,
-    ) {
-        if let Some((_, handle)) = bodies.0.get_unknown_gen(handle) {
-            bodies
-                .0
-                .remove(handle, &mut islands.0, &mut colliders.0, &mut joints.0);
-        }
-    }
-
-    // TODO: BREAKING, remove this, and add the corresponding remove/maintain method to the sets
-    // and narrow/broad phases.
-    pub fn removeCollider(
-        &mut self,
-        handle: u32,
-        islands: &mut RawIslandManager,
-        bodies: &mut RawRigidBodySet,
-        colliders: &mut RawColliderSet,
-    ) {
-        if let Some((_, handle)) = colliders.0.get_unknown_gen(handle) {
-            colliders
-                .0
-                .remove(handle, &mut islands.0, &mut bodies.0, true);
-        }
-    }
 }

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -4,8 +4,8 @@ use crate::geometry::{
     RawShape, RawShapeColliderTOI,
 };
 use crate::math::{RawRotation, RawVector};
-use rapier::geometry::{ColliderHandle, Ray};
-use rapier::math::Isometry;
+use rapier::geometry::{ColliderHandle, Ray, AABB};
+use rapier::math::{Isometry, Point};
 use rapier::pipeline::QueryPipeline;
 use wasm_bindgen::prelude::*;
 
@@ -225,5 +225,26 @@ impl RawQueryPipeline {
             None,
             rcallback,
         )
+    }
+
+    pub fn collidersWithAabbIntersectingAabb(
+        &self,
+        aabbCenter: RawVector,
+        aabbHalfExtents: RawVector,
+        callback: &js_sys::Function,
+    ) {
+        let this = JsValue::null();
+        let rcallback = |handle: &ColliderHandle| match callback
+            .call1(&this, &JsValue::from(handle.into_raw_parts().0 as u32))
+        {
+            Err(_) => true,
+            Ok(val) => val.as_bool().unwrap_or(true),
+        };
+
+        let center = Point::from(aabbCenter.0);
+        let aabb = AABB::new(center - aabbHalfExtents.0, center + aabbHalfExtents.0);
+
+        self.0
+            .colliders_with_aabb_intersecting_aabb(&aabb, rcallback)
     }
 }

--- a/testbed2d/package.json
+++ b/testbed2d/package.json
@@ -11,7 +11,7 @@
     "test": "cargo test && wasm-pack test --headless"
   },
   "dependencies": {
-    "@dimforge/rapier2d": "^0.6.0",
+    "@dimforge/rapier2d": "^0.7.0",
     "dat.gui": "^0.7.7",
     "matter-js": "^0.14.2",
     "md5": "^2.2.1",

--- a/testbed3d/package.json
+++ b/testbed3d/package.json
@@ -11,7 +11,7 @@
     "test": "cargo test && wasm-pack test --headless"
   },
   "dependencies": {
-    "@dimforge/rapier3d": "^0.6.0",
+    "@dimforge/rapier3d": "^0.7.0",
     "buffer-crc32": "^0.2.13",
     "cannon": "^0.6.2",
     "cannon-es": "^0.14.0",
@@ -21,7 +21,7 @@
     "physx-js": "^0.0.6",
     "seedrandom": "^3.0.5",
     "stats.js": "^0.17.0",
-    "three": "0.118",
+    "three": "^0.130.1",
     "worker-loader": "^2.0.0"
   },
   "devDependencies": {

--- a/testbed3d/src/PhysicsDescription.js
+++ b/testbed3d/src/PhysicsDescription.js
@@ -3,7 +3,7 @@ export function extractRigidBodyDescription(body) {
 
     return {
         handle: body.handle,
-        type: body.bodyStatus(),
+        type: body.bodyType(),
         translation: pos,
         linvel: body.linvel(),
         angvel: body.angvel(),


### PR DESCRIPTION
### Breaking change
- The `World.castRay` and `World.castRayAndGetNormal` methods have a different signature now, making them
  more flexible.
- Rename `ActiveHooks::FILTER_CONTACT_PAIR` to `ActiveHooks.FILTER_CONTACT_PAIRS`.
- Rename `ActiveHooks::FILTER_INTERSECTION_PAIR` to `ActiveHooks.FILTER_INTERSECTION_PAIRS`.
- Rename `BodyStatus` to `RigidBodyType`.  
- Rename `RigidBody.bodyStatus()` to `RigidBody.bodyType()`.
- Rename `RigidBodyDesc.setMassProperties` to `RigidBodyDesc.setAdditionalMassProperties`.
- Rename `RigidBodyDesc.setPrincipalAngularInertia` to `RigidBodyDesc.setAdditionalPrincipalAngularInertia`.
- Rename `ColliderDesc.setIsSensor` to `ColliderDesc.setSensor.

### Added
- Add `Ray.pointAt(t)` that conveniently computes `ray.origin + ray.dir * t`.
- Add access to joint motors by defining each joint with its own class deriving from `Joint`. Each joint now
  have its relevant motor configuration methods: `configurMotorModel, configureMotorVelocity, configureMotorPosition, configureMotor`.
- Add `World.collidersWithAabbIntersectingAabb` for retrieving the handles of all the colliders intersecting the given AABB.  
- Add many missing methods for reading/modifying a rigid-body state after its creation:
  * `RigidBody.lockTranslations`
  * `RigidBody.lockRotations`
  * `RigidBody.restrictRotations`
  * `RigidBody.dominanceGroup`
  * `RigidBody.setDominanceGroup`
  * `RigidBody.enableCcd`
- Add `RigidBodyDesc.setDominanceGroup` for setting the dominance group of the rigid-body being built.  
- Add many missing methods for reading/modifying a collider state after its creation:
  * `Collider.setSendor`
  * `Collider.setShape`
  * `Collider.setRestitution`
  * `Collider.setFriction`
  * `Collider.frictionCombineRule`
  * `Collider.setFrictionCombineRule`
  * `Collider.restitutionCombineRule`
  * `Collider.setRestitutionCombineRule`
  * `Collider.setCollisionGroups`
  * `Collider.setSolverGroups`
  * `Collider.activeHooks`
  * `Collider.setActiveHooks`
  * `Collider.activeEvents`
  * `Collider.setActiveEvents`
  * `Collider.activeCollisionTypes`
  * `Collider.setTranslation`
  * `Collider.setTranslationWrtParent`
  * `Collider.setRotation`
  * `Collider.setRotationWrtParent`
- Add `ColliderDesc.setMassProperties` for setting explicitly the mass properties of the collider being built (instead of relying on density).