### PR TITLE
Basic framework for TypeScript unit tests.

### DIFF
--- a/rapier-compat/README.md
+++ b/rapier-compat/README.md
@@ -1,0 +1,6 @@
+# tsconfig,json files:
+
+* tsconfig.common.json - shared TypeScript options
+* tsconfig.pkg2d.json - config for compiling rapier2d-compat
+* tsconfig.pkg3d.json - config for compiling rapier3d-compat
+* tconfig.json - for IDE (VSCode) and unit tests. Includes Jest types.

--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -10,17 +10,42 @@
     "build-js": "rollup --config rollup.config.js",
     "build": "npm run clean && npm run build-rust && npm run build-genjs && npm run build-js",
     "clean": "npx rimraf ../rapier2d/pkg ../rapier3d/pkg pkg2d pkg3d gen2d gen3d ../rapier2d/docs ../rapier3d/docs",
+    "test": "jest --detectOpenHandles",
     "all": "npm run build"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.3",
+    "@types/jest": "^26.0.24",
+    "jest": "^27.0.6",
+    "jest-cli": "^27.0.6",
     "rimraf": "^3.0.2",
     "rollup": "^2.53.2",
     "rollup-plugin-base64": "^1.0.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-terser": "^7.0.2",
+    "ts-jest": "^27.0.4",
     "tslib": "^2.3.0",
     "typescript": "^4.1.3"
+  },
+  "jest": {
+    "roots": [
+      "<rootDir>/tests"
+    ],
+    "preset": "ts-jest",
+    "collectCoverageFrom": [
+      "pkg2d/**/*.js",
+      "pkg3d/**/*.js"
+    ],
+    "testURL": "http://localhost",
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|ts)$",
+      "[/\\\\]pkg3d[/\\\\].+\\.(js|ts)$",
+      "[/\\\\]pkg2d[/\\\\].+\\.(js|ts)$"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ]
   }
 }

--- a/rapier-compat/tests/World2d.test.ts
+++ b/rapier-compat/tests/World2d.test.ts
@@ -1,0 +1,23 @@
+import { init, Vector2, World } from "../pkg2d";
+
+describe("2d/World", () => {
+  let world: World;
+
+  beforeAll(init);
+
+  afterAll(async () => {
+    await Promise.resolve();
+  });
+
+  beforeEach(() => {
+    world = new World(new Vector2(0, 9.8));
+  });
+
+  afterEach(() => {
+    world.free();
+  });
+
+  test("constructor", () => {
+    expect(world.colliders.len()).toBe(0);
+  });
+});

--- a/rapier-compat/tests/World3d.test.ts
+++ b/rapier-compat/tests/World3d.test.ts
@@ -1,0 +1,23 @@
+import { init, Vector3, World } from "../pkg3d";
+
+describe("3d/World", () => {
+  let world: World;
+
+  beforeAll(init);
+
+  afterAll(async () => {
+    await Promise.resolve();
+  });
+
+  beforeEach(() => {
+    world = new World(new Vector3(0, 9.8, 0));
+  });
+
+  afterEach(() => {
+    world.free();
+  });
+
+  test("constructor", () => {
+    expect(world.colliders.len()).toBe(0);
+  });
+});

--- a/rapier-compat/tests/math2d.test.ts
+++ b/rapier-compat/tests/math2d.test.ts
@@ -1,0 +1,15 @@
+import { Vector2, VectorOps } from '../pkg2d';
+
+describe('2d/math', () => {
+  test('Vector2', () => {
+    const v = new Vector2(0, 1);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(1);
+  });
+
+  test('VectorOps', () => {
+    const v = VectorOps.new(0, 1);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(1);
+  });
+});

--- a/rapier-compat/tests/math3d.test.ts
+++ b/rapier-compat/tests/math3d.test.ts
@@ -1,0 +1,17 @@
+import { Vector3, VectorOps } from '../pkg3d';
+
+describe('3d/math', () => {
+  test('Vector3', () => {
+    const v = new Vector3(0, 1, 2);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(1);
+    expect(v.z).toBe(2);
+  });
+
+  test('VectorOps', () => {
+    const v = VectorOps.new(0, 1, 2);
+    expect(v.x).toBe(0);
+    expect(v.y).toBe(1);
+    expect(v.z).toBe(2);
+  });
+});

--- a/rapier-compat/tsconfig.json
+++ b/rapier-compat/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.common.json",
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "DOM"
+    ],
+    "esModuleInterop": true,
+    "types": ["jest"],
+    "outDir": "./dist"
+  },
+  "include": ["./tests/**/*.test.ts"]
+}


### PR DESCRIPTION
This PR demonstrates a unit test for rapier-compat (2d and 3d) which initalizes WASM, creates a World object, and tests one of its methods.