### PR TITLE
Return a valid half-extent for round cuboids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.7.3 - WIP 
+### Fixed
+- The `collider.halfExtents()` methods now returns a valid value for round cuboids.
+
 ### 0.7.2 (rapier-compat only)
 ### Modified
 - The `rapier-compat` packages don’t need the `Buffer` polyfill anymore.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -144,6 +144,7 @@ impl RawColliderSet {
     pub fn coHalfExtents(&self, handle: u32) -> Option<RawVector> {
         self.map(handle, |co| {
             co.shape().as_cuboid().map(|c| c.half_extents.into())
+                .or_else(|| co.shape().as_round_cuboid().map(|c| c.base_shape.half_extents.into()))
         })
     }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -143,8 +143,14 @@ impl RawColliderSet {
     /// The half-extents of this collider if it is has a cuboid shape.
     pub fn coHalfExtents(&self, handle: u32) -> Option<RawVector> {
         self.map(handle, |co| {
-            co.shape().as_cuboid().map(|c| c.half_extents.into())
-                .or_else(|| co.shape().as_round_cuboid().map(|c| c.base_shape.half_extents.into()))
+            co.shape()
+                .as_cuboid()
+                .map(|c| c.half_extents.into())
+                .or_else(|| {
+                    co.shape()
+                        .as_round_cuboid()
+                        .map(|c| c.base_shape.half_extents.into())
+                })
         })
     }
 


### PR DESCRIPTION
Fix #37 