### PR TITLE
Fix collider creation when it has no parent

### DIFF
--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -31,7 +31,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "^27.0.4",
     "tslib": "^2.3.0",
-    "typescript": "^4.1.3"
+    "typescript": "=4.3.5"
   },
   "jest": {
     "roots": [

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier2d" # Can't be named rapier2d which conflicts with the dependency.
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust - official JS bindings."
 documentation = "http://rapier.rs/rustdoc/rapier2d/index.html"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier3d" # Can't be named rapier3d which conflicts with the dependency.
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust - official JS bindings."
 documentation = "http://rapier.rs/rustdoc/rapier2d/index.html"


### PR DESCRIPTION
This PR fixes the case where the collider creation would fail if it isn’t attached to any parent _and_ no rigid-bodies have been added since the beginning of the physics setup.