### PR TITLE
Expose Restitution and fix lookup IDs

### DIFF
--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
-    "@rollup/plugin-typescript": "^8.2.3",
+    "@rollup/plugin-typescript": "=8.2.3",
     "@types/jest": "^26.0.24",
     "jest": "^27.0.6",
     "jest-cli": "^27.0.6",

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -421,6 +421,13 @@ export class Collider {
     }
 
     /**
+     * The restitution coefficient of this collider.
+     */
+    public restitution(): number {
+        return this.rawSet.coRestitution(this.handle);
+    }
+
+    /**
      * The density of this collider.
      */
     public density(): number {

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -193,7 +193,7 @@ export class Collider {
      * Get the physics hooks active for this collider.
      */
     public activeHooks() {
-        this.rawSet.coActiveHooks(this.handle);
+        return this.rawSet.coActiveHooks(this.handle);
     }
 
     /**

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -308,6 +308,10 @@ impl RawColliderSet {
     pub fn coFriction(&self, handle: u32) -> f32 {
         self.map(handle, |co| co.material().friction)
     }
+    /// The restitution coefficient of this collider.
+    pub fn coRestitution(&self, handle: u32) -> f32 {
+        self.map(handle, |co| co.material().restitution)
+    }
 
     /// The density of this collider.
     pub fn coDensity(&self, handle: u32) -> Option<f32> {

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -100,7 +100,7 @@ impl RawContactManifold {
     }
 
     pub fn local_n2(&self) -> RawVector {
-        unsafe { (*self.0).local_n1.into() }
+        unsafe { (*self.0).local_n2.into() }
     }
 
     pub fn subshape1(&self) -> u32 {
@@ -108,7 +108,7 @@ impl RawContactManifold {
     }
 
     pub fn subshape2(&self) -> u32 {
-        unsafe { (*self.0).subshape1 }
+        unsafe { (*self.0).subshape2 }
     }
 
     pub fn num_contacts(&self) -> usize {
@@ -120,7 +120,7 @@ impl RawContactManifold {
     }
 
     pub fn contact_local_p2(&self, i: usize) -> Option<RawVector> {
-        unsafe { (*self.0).points.get(i).map(|c| c.local_p1.coords.into()) }
+        unsafe { (*self.0).points.get(i).map(|c| c.local_p2.coords.into()) }
     }
 
     pub fn contact_dist(&self, i: usize) -> Real {

--- a/src/geometry/toi.rs
+++ b/src/geometry/toi.rs
@@ -23,7 +23,7 @@ impl RawShapeColliderTOI {
     }
 
     pub fn witness2(&self) -> RawVector {
-        self.toi.witness1.coords.into()
+        self.toi.witness2.coords.into()
     }
 
     pub fn normal1(&self) -> RawVector {
@@ -31,6 +31,6 @@ impl RawShapeColliderTOI {
     }
 
     pub fn normal2(&self) -> RawVector {
-        self.toi.normal1.into_inner().into()
+        self.toi.normal2.into_inner().into()
     }
 }


### PR DESCRIPTION
This PR fixes some typos in the lookup ID's, exposes the collider restitution, and also pins the rollup typescript version as 8.2.4 was causing a bug with compilation. 