### PR TITLE
Fix some null pointer crashes

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -402,7 +402,7 @@ impl RawColliderSet {
         self.map_mut(handle, |co| co.set_active_collision_types(types));
     }
 
-    pub fn coSetShape(&mut self, handle: u32, shape: RawShape) {
-        self.map_mut(handle, |co| co.set_shape(shape.0));
+    pub fn coSetShape(&mut self, handle: u32, shape: &RawShape) {
+        self.map_mut(handle, |co| co.set_shape(shape.0.clone()));
     }
 }

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -229,8 +229,8 @@ impl RawQueryPipeline {
 
     pub fn collidersWithAabbIntersectingAabb(
         &self,
-        aabbCenter: RawVector,
-        aabbHalfExtents: RawVector,
+        aabbCenter: &RawVector,
+        aabbHalfExtents: &RawVector,
         callback: &js_sys::Function,
     ) {
         let this = JsValue::null();


### PR DESCRIPTION
This fixes `collider.setShape` and `world.collidersWithAabbIntersectingAabb` that crashed because of a null pointer error.
Fix #50 