### PR TITLE
Add bindings to cast rays or project points on a single collider

### DIFF
--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -15,7 +15,8 @@ import {
     ConvexPolyhedron, RoundConvexPolyhedron,
     // #endif
 } from './shape';
-import { PointProjection, Ray, RayIntersection } from ".";
+import { Ray, RayIntersection } from "./ray";
+import { PointProjection } from "./point";
 
 /// Flags affecting whether or not collision-detection happens between two colliders
 /// depending on the type of rigid-bodies they are attached to.
@@ -513,6 +514,39 @@ export class Collider {
             rawOrig,
             rawDir,
             maxToi,
+        );
+
+        rawOrig.free();
+        rawDir.free();
+
+        return result;
+    }
+
+    /*
+     * Find the closest intersection between a ray and this collider.
+     *
+     * This also computes the normal at the hit point.
+     * @param ray - The ray to cast.
+     * @param maxToi - The maximum time-of-impact that can be reported by this cast. This effectively
+     *   limits the length of the ray to `ray.dir.norm() * maxToi`.
+     * @param solid - If `false` then the ray will attempt to hit the boundary of a shape, even if its
+     *   origin already lies inside of a shape. In other terms, `true` implies that all shapes are plain,
+     *   whereas `false` implies that all shapes are hollow for this ray-cast.
+     * @returns The time-of-impact between this collider and the ray, or `-1` if there is no intersection.
+     */
+    public castRay(
+        ray: Ray,
+        maxToi: number,
+        solid: boolean,
+    ): number {
+        let rawOrig = VectorOps.intoRaw(ray.origin);
+        let rawDir = VectorOps.intoRaw(ray.dir);
+        let result = this.rawSet.coCastRay(
+            this.handle,
+            rawOrig,
+            rawDir,
+            maxToi,
+            solid,
         );
 
         rawOrig.free();

--- a/src.ts/geometry/point.ts
+++ b/src.ts/geometry/point.ts
@@ -1,9 +1,41 @@
-import {ColliderHandle} from "./collider";
-import {Vector, VectorOps} from "../math";
-import {RawPointColliderProjection} from "../raw";
+import { ColliderHandle } from "./collider";
+import { Vector, VectorOps } from "../math";
+import { RawPointColliderProjection, RawPointProjection } from "../raw";
+
 
 /**
- * The intersection between a ray and a collider.
+ * The projection of a point on a collider.
+ */
+export class PointProjection {
+    /**
+     * The projection of the point on the collider.
+     */
+    point: Vector
+    /**
+     * Is the point inside of the collider?
+     */
+    isInside: boolean
+
+    constructor(point: Vector, isInside: boolean) {
+        this.point = point;
+        this.isInside = isInside;
+    }
+
+    public static fromRaw(raw: RawPointProjection): PointProjection {
+        if (!raw)
+            return null;
+
+        const result = new PointProjection(
+            VectorOps.fromRaw(raw.point()),
+            raw.isInside()
+        );
+        raw.free();
+        return result;
+    }
+}
+
+/**
+ * The projection of a point on a collider (includes the collider handle).
  */
 export class PointColliderProjection {
     /**

--- a/src.ts/geometry/ray.ts
+++ b/src.ts/geometry/ray.ts
@@ -1,6 +1,6 @@
-import {Vector, VectorOps} from "../math";
-import {RawRayColliderIntersection, RawRayColliderToi} from "../raw";
-import {ColliderHandle} from "./collider";
+import { Vector, VectorOps } from "../math";
+import { RawRayColliderIntersection, RawRayColliderToi, RawRayIntersection } from "../raw";
+import { ColliderHandle } from "./collider";
 
 /**
  * A ray. This is a directed half-line.
@@ -37,8 +37,42 @@ export class Ray {
     };
 }
 
+
 /**
  * The intersection between a ray and a collider.
+ */
+export class RayIntersection {
+    /**
+     * The time-of-impact of the ray with the collider.
+     *
+     * The hit point is obtained from the ray's origin and direction: `origin + dir * toi`.
+     */
+    toi: number
+    /**
+     * The normal of the collider at the hit point.
+     */
+    normal: Vector
+
+    constructor(toi: number, normal: Vector) {
+        this.toi = toi;
+        this.normal = normal;
+    }
+
+    public static fromRaw(raw: RawRayIntersection): RayIntersection {
+        if (!raw)
+            return null;
+
+        const result = new RayIntersection(
+            raw.toi(),
+            VectorOps.fromRaw(raw.normal())
+        );
+        raw.free();
+        return result;
+    }
+}
+
+/**
+ * The intersection between a ray and a collider (includes the collider handle).
  */
 export class RayColliderIntersection {
     /**

--- a/src/dynamics/joint.rs
+++ b/src/dynamics/joint.rs
@@ -9,11 +9,21 @@ use rapier::math::Isometry;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+#[cfg(feature = "dim2")]
 pub enum RawJointType {
-    Spherical,
+    Revolute,
     Fixed,
     Prismatic,
+    Generic,
+}
+
+#[wasm_bindgen]
+#[cfg(feature = "dim3")]
+pub enum RawJointType {
     Revolute,
+    Fixed,
+    Prismatic,
+    Spherical,
     Generic,
 }
 

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -3,6 +3,20 @@ use rapier::geometry::{ColliderHandle, PointProjection};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+pub struct RawPointProjection(pub(crate) PointProjection);
+
+#[wasm_bindgen]
+impl RawPointProjection {
+    pub fn point(&self) -> RawVector {
+        self.0.point.coords.into()
+    }
+
+    pub fn isInside(&self) -> bool {
+        self.0.is_inside
+    }
+}
+
+#[wasm_bindgen]
 pub struct RawPointColliderProjection {
     pub(crate) handle: ColliderHandle,
     pub(crate) proj: PointProjection,

--- a/src/geometry/ray.rs
+++ b/src/geometry/ray.rs
@@ -3,6 +3,20 @@ use rapier::geometry::{ColliderHandle, RayIntersection};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+pub struct RawRayIntersection(pub(crate) RayIntersection);
+
+#[wasm_bindgen]
+impl RawRayIntersection {
+    pub fn normal(&self) -> RawVector {
+        self.0.normal.into()
+    }
+
+    pub fn toi(&self) -> f32 {
+        self.0.toi
+    }
+}
+
+#[wasm_bindgen]
 pub struct RawRayColliderIntersection {
     pub(crate) handle: ColliderHandle,
     pub(crate) inter: RayIntersection,


### PR DESCRIPTION
This adds methods to the `Collider` object: `containsPoint, projectPoint, castRay, castRayAndGetNormal, intersectsRay`.
This also fixes the ordering of joint variants (fix #68).