### PR TITLE
improve TS compiling config

### DIFF
--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -3,8 +3,8 @@
   "description": "Build scripts for compatibility package with inlined webassembly as base64.",
   "private": true,
   "scripts": {
-    "build-rust-2d": "cd ../rapier2d ; wasm-pack build --target web",
-    "build-rust-3d": "cd ../rapier3d ; wasm-pack build --target web",
+    "build-rust-2d": "cd ../rapier2d && wasm-pack build --target web",
+    "build-rust-3d": "cd ../rapier3d && wasm-pack build --target web",
     "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
     "build-genjs": "sh ./gen_src.sh",
     "build-js": "rollup --config rollup.config.js",

--- a/rapier-compat/tsconfig.common.json
+++ b/rapier-compat/tsconfig.common.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "module": "es2015",
-    "target": "es5",
+    "module": "ES6",
+    "target": "es6",
     "noEmitOnError": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictFunctionTypes": true,
     "lib": [
-      "es5",
+      "es6",
       "DOM"
     ],
     "moduleResolution": "node",

--- a/rapier-compat/tsconfig.json
+++ b/rapier-compat/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
-    "lib": [
-      "es2015",
-      "DOM"
-    ],
     "esModuleInterop": true,
     "types": ["jest"],
     "outDir": "./dist"

--- a/rapier2d/tsconfig.json
+++ b/rapier2d/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./pkg",
-    "module": "es2015",
-    "target": "es5",
+    "module": "es6",
+    "target": "es6",
     "lib": [
-      "es5"
+      "es6"
     ],
     "moduleResolution": "node",
     "sourceMap": true,

--- a/rapier3d/tsconfig.json
+++ b/rapier3d/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./pkg",
-    "module": "es2015",
-    "target": "es5",
+    "module": "es6",
+    "target": "es6",
     "lib": [
-      "es5"
+      "es6"
     ],
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
1, modify the chr ';' as '&&' in rapier-compat/package.json which will work for multiple platform when execute `npm run build`

2, change TS compiling target as ES6 for better performance, because there is no reason why use ES5 which is little too old now, and if an platform supports WebAssembly, the ES6 module is a basic requirement.
