### PR TITLE
fix for #60

### DIFF
--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -188,16 +188,30 @@ impl RawColliderSet {
         })
     }
 
-    /// The radius of the round edges of this collider if it is a round cylinder.
+    /// The radius of the round edges of this collider.
     pub fn coRoundRadius(&self, handle: u32) -> Option<f32> {
         self.map(handle, |co| match co.shape().shape_type() {
+            ShapeType::RoundCuboid => co.shape().as_round_cuboid().map(|b| b.border_radius),
+            ShapeType::RoundTriangle => co.shape().as_round_triangle().map(|b| b.border_radius),
             #[cfg(feature = "dim3")]
             ShapeType::RoundCylinder => co.shape().as_round_cylinder().map(|b| b.border_radius),
+            #[cfg(feature = "dim3")]
+            ShapeType::RoundCone => co.shape().as_round_cone().map(|b| b.border_radius),
+            #[cfg(feature = "dim3")]
+            ShapeType::RoundConvexPolyhedron => co
+                .shape()
+                .as_round_convex_polyhedron()
+                .map(|b| b.border_radius),
+            #[cfg(feature = "dim2")]
+            ShapeType::RoundConvexPolygon => co
+                .shape()
+                .as_round_convex_polygon()
+                .map(|b| b.border_radius),
             _ => None,
         })
     }
 
-    /// The vertices of this triangle mesh, polyline, convex polyhedron, or convex polyhedron, if it is one.
+    /// The vertices of this triangle mesh, polyline, convex polyhedron, segment, triangle or convex polyhedron, if it is one.
     pub fn coVertices(&self, handle: u32) -> Option<Vec<f32>> {
         let flatten =
             |vertices: &[Point<f32>]| vertices.iter().flat_map(|p| p.iter()).copied().collect();
@@ -222,6 +236,12 @@ impl RawColliderSet {
                 .shape()
                 .as_round_convex_polygon()
                 .map(|p| flatten(p.base_shape.points())),
+            ShapeType::Segment => co.shape().as_segment().map(|s| flatten(&[s.a, s.b])),
+            ShapeType::RoundTriangle => co
+                .shape()
+                .as_round_triangle()
+                .map(|t| flatten(&[t.base_shape.a, t.base_shape.b, t.base_shape.c])),
+            ShapeType::Triangle => co.shape().as_triangle().map(|t| flatten(&[t.a, t.b, t.c])),
             _ => None,
         })
     }


### PR DESCRIPTION
1, for retrieve 
```
segment.a / .b
triangle.a / .b / .c
```
because there is no such API on `Collider`
so implemented on `vertices`
if wanna retrieve `segment.a / .b` or `triangle.a / .b / .c`, use `c.vertices` instead

2, `c.roundRadius()` now available for all round shapes

![image](https://user-images.githubusercontent.com/850854/155743550-24f772b8-c871-485a-b886-361d4bfd8f1a.png)

tested and now `c.borderRadius()` and `c.vertices()` work correctly.
