### PR TITLE
optional `collider.parent()`

### DIFF
--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -411,7 +411,7 @@ export class Collider {
     /**
      * The unique integer identifier of the rigid-body this collider is attached to.
      */
-    public parent(): RigidBodyHandle {
+    public parent(): RigidBodyHandle | undefined {
         return this.rawSet.coParent(this.handle);
     }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -301,9 +301,7 @@ impl RawColliderSet {
 
     /// The unique integer identifier of the collider this collider is attached to.
     pub fn coParent(&self, handle: u32) -> Option<u32> {
-        self.map(handle, |co| {
-            co.parent().map(|p| p.into_raw_parts().0)
-        })
+        self.map(handle, |co| co.parent().map(|p| p.into_raw_parts().0))
     }
 
     /// The friction coefficient of this collider.

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -300,9 +300,9 @@ impl RawColliderSet {
     }
 
     /// The unique integer identifier of the collider this collider is attached to.
-    pub fn coParent(&self, handle: u32) -> u32 {
+    pub fn coParent(&self, handle: u32) -> Option<u32> {
         self.map(handle, |co| {
-            co.parent().map(|p| p.into_raw_parts().0).unwrap_or(0)
+            co.parent().map(|p| p.into_raw_parts().0)
         })
     }
 


### PR DESCRIPTION
`collider.parent()` will now return `undefined` that indicates it does not have parent.
fix for #89