### PR TITLE
use cache mechanism to avoid creating unnecessary RigidBody / Collider instances.

### DIFF
--- a/rapier-compat/tsconfig.common.json
+++ b/rapier-compat/tsconfig.common.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "module": "es2015",
-    "target": "es5",
+    "module": "ES6",
+    "target": "es6",
     "noEmitOnError": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictFunctionTypes": true,
     "lib": [
-      "es5",
+      "es6",
       "DOM"
     ],
     "moduleResolution": "node",

--- a/rapier-compat/tsconfig.json
+++ b/rapier-compat/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.common.json",
   "compilerOptions": {
     "lib": [
-      "es2015",
+      "es6",
       "DOM"
     ],
     "esModuleInterop": true,

--- a/rapier2d/tsconfig.json
+++ b/rapier2d/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./pkg",
-    "module": "es2015",
-    "target": "es5",
+    "module": "ES6",
+    "target": "es6",
     "lib": [
-      "es5"
+      "es6"
     ],
     "moduleResolution": "node",
     "sourceMap": true,

--- a/rapier3d/tsconfig.json
+++ b/rapier3d/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "outDir": "./pkg",
-    "module": "es2015",
-    "target": "es5",
+    "module": "ES6",
+    "target": "es6",
     "lib": [
-      "es5"
+      "es6"
     ],
     "moduleResolution": "node",
     "sourceMap": true,

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -46,6 +46,11 @@ export enum RigidBodyType {
 export class RigidBody {
     private rawSet: RawRigidBodySet; // The RigidBody won't need to free this.
     readonly handle: RigidBodyHandle;
+    
+    /**
+     * An arbitrary user-defined object associated with this rigid-body.
+     */
+    public userData?: unknown;
 
     constructor(rawSet: RawRigidBodySet, handle: RigidBodyHandle) {
         this.rawSet = rawSet;
@@ -634,22 +639,6 @@ export class RigidBody {
         rawImpulse.free();
         rawPoint.free();
     }
-
-    /**
-     * An arbitrary user-defined 32-bit integer
-     */
-    public get userData(): number {
-        return this.rawSet.rbUserData(this.handle);
-    }
-
-    /**
-     * Sets the user-defined 32-bit integer of this rigid-body.
-     * 
-     * @param userData - The user-defined 32-bit integer to set.
-     */
-    public set userData(value: number) {
-        this.rawSet.rbSetUserData(this.handle, value);
-    }
 }
 
 export class RigidBodyDesc {
@@ -681,6 +670,7 @@ export class RigidBodyDesc {
     canSleep: boolean;
     ccdEnabled: boolean;
     dominanceGroup: number;
+    userData?: unknown;
 
     constructor(status: RigidBodyType) {
         this.status = status;
@@ -1084,6 +1074,16 @@ export class RigidBodyDesc {
      */
     public setCcdEnabled(enabled: boolean): RigidBodyDesc {
         this.ccdEnabled = enabled;
+        return this;
+    }
+
+    /**
+     * Sets the user-defined object of this rigid-body.
+     * 
+     * @param userData - The user-defined object to set.
+     */
+    public setUserData(data?: unknown): RigidBodyDesc {
+        this.userData = data;
         return this;
     }
 }


### PR DESCRIPTION
Changes:

1. ES6 output by default
2. an internal cache for created `RigidBody` and `Collider` instances
    (actually wanted to make the 'raw' filed to be private as well to avoid user from calling `raw.remove` etc operations, and for internal friend classes to access this field, we can add `@ts-ignore` to force access this private field, but i saw other pipelines are all have this problem so in this PR i didn't change it)
3. a naive plain `userData` field in `RigidBody` class (just a stub)
4. 2 new methods: `getAllHandles` & `getAllColliders / getAllBodies`

Drawback:

when serialization / deserialization, `userData` will be lost, but i think this is normal because that field is just a handy handle, so user needs to take care of it.

Test:
![image](https://user-images.githubusercontent.com/850854/159434110-0d62c4de-40b4-4252-a4aa-144f704837e0.png)
