### PR TITLE
added utilities for Shape

### DIFF
--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -600,6 +600,29 @@ export class Collider {
         return result;
     }
 
+    public intersectsShape(
+        shape2: Shape,
+        shapePos2: Vector,
+        shapeRot2: Rotation,
+    ): boolean {
+        let rawPos2 = VectorOps.intoRaw(shapePos2);
+        let rawRot2 = RotationOps.intoRaw(shapeRot2);
+        let rawShape2 = shape2.intoRaw();
+
+        let result = this.rawSet.coIntersectsShape(
+            this.handle,
+            rawShape2,
+            rawPos2,
+            rawRot2
+        );
+
+        rawPos2.free();
+        rawRot2.free();
+        rawShape2.free();
+
+        return result;
+    }
+
     /**
      * Computes one pair of contact points between the shape owned by this collider and the given shape.
      *

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -1,6 +1,8 @@
 import { Vector, VectorOps, Rotation, RotationOps } from "../math"
 import { RawShape } from "../raw";
 import { ShapeContact } from "./contact";
+import { PointProjection } from "./point";
+import { RayIntersection } from "./ray";
 import { ShapeTOI } from "./toi";
 
 export abstract class Shape {
@@ -144,6 +146,150 @@ export abstract class Shape {
 
         rawShape1.free();
         rawShape2.free();
+
+        return result;
+    }
+
+    containsPoint(
+        shapePos: Vector,
+        shapeRot: Rotation,
+        point: Vector,
+    ): boolean {
+        let rawPos = VectorOps.intoRaw(shapePos);
+        let rawRot = RotationOps.intoRaw(shapeRot);
+        let rawPoint = VectorOps.intoRaw(point);
+
+        let rawShape = this.intoRaw();
+
+        let result = rawShape.containsPoint(
+            rawPos,
+            rawRot,
+            rawPoint
+        );
+
+        rawPos.free();
+        rawRot.free();
+        rawPoint.free();
+
+        return result;
+    }
+
+    projectPoint(
+        shapePos: Vector,
+        shapeRot: Rotation,
+        point: Vector,
+        solid: boolean
+    ): PointProjection {
+        let rawPos = VectorOps.intoRaw(shapePos);
+        let rawRot = RotationOps.intoRaw(shapeRot);
+        let rawPoint = VectorOps.intoRaw(point);
+
+        let rawShape = this.intoRaw();
+
+        let result = PointProjection.fromRaw(rawShape.projectPoint(
+            rawPos,
+            rawRot,
+            rawPoint,
+            solid
+        ));
+
+        rawPos.free();
+        rawRot.free();
+        rawPoint.free();
+
+        return result;
+    }
+
+    intersectsRay(
+        shapePos: Vector,
+        shapeRot: Rotation,
+        rayOrig: Vector,
+        rayDir: Vector,
+        maxToi: number,
+    ): boolean {
+        let rawPos = VectorOps.intoRaw(shapePos);
+        let rawRot = RotationOps.intoRaw(shapeRot);
+        let rawRayOrig = VectorOps.intoRaw(rayOrig);
+        let rawRayDir = VectorOps.intoRaw(rayDir);
+
+        let rawShape = this.intoRaw();
+
+        let result = rawShape.intersectsRay(
+            rawPos,
+            rawRot,
+            rawRayOrig,
+            rawRayDir,
+            maxToi
+        );
+
+        rawPos.free();
+        rawRot.free();
+        rawRayOrig.free();
+        rawRayDir.free();
+
+        return result;
+    }
+
+    castRay(
+        shapePos: Vector,
+        shapeRot: Rotation,
+        rayOrig: Vector,
+        rayDir: Vector,
+        maxToi: number,
+        solid: boolean
+    ): number {
+        let rawPos = VectorOps.intoRaw(shapePos);
+        let rawRot = RotationOps.intoRaw(shapeRot);
+        let rawRayOrig = VectorOps.intoRaw(rayOrig);
+        let rawRayDir = VectorOps.intoRaw(rayDir);
+
+        let rawShape = this.intoRaw();
+
+        let result = rawShape.castRay(
+            rawPos,
+            rawRot,
+            rawRayOrig,
+            rawRayDir,
+            maxToi,
+            solid
+        );
+
+        rawPos.free();
+        rawRot.free();
+        rawRayOrig.free();
+        rawRayDir.free();
+
+        return result;
+    }
+
+    castRayAndGetNormal(
+        shapePos: Vector,
+        shapeRot: Rotation,
+        rayOrig: Vector,
+        rayDir: Vector,
+        maxToi: number,
+        solid: boolean,
+    ): RayIntersection {
+        let rawPos = VectorOps.intoRaw(shapePos);
+        let rawRot = RotationOps.intoRaw(shapeRot);
+        let rawRayOrig = VectorOps.intoRaw(rayOrig);
+        let rawRayDir = VectorOps.intoRaw(rayDir);
+
+        let rawShape = this.intoRaw();
+
+        let result = RayIntersection.fromRaw(rawShape.castRayAndGetNormal(
+            rawPos,
+            rawRot,
+            rawRayOrig,
+            rawRayDir,
+            maxToi,
+            solid
+        ));
+
+        rawPos.free();
+        rawRot.free();
+        rawRayOrig.free();
+        rawRayDir.free();
 
         return result;
     }

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -2,7 +2,7 @@ import { Vector, VectorOps, Rotation, RotationOps } from "../math"
 import { RawShape } from "../raw";
 import { ShapeContact } from "./contact";
 import { PointProjection } from "./point";
-import { RayIntersection } from "./ray";
+import { Ray, RayIntersection } from "./ray";
 import { ShapeTOI } from "./toi";
 
 export abstract class Shape {
@@ -201,16 +201,15 @@ export abstract class Shape {
     }
 
     intersectsRay(
+        ray: Ray,
         shapePos: Vector,
         shapeRot: Rotation,
-        rayOrig: Vector,
-        rayDir: Vector,
         maxToi: number,
     ): boolean {
         let rawPos = VectorOps.intoRaw(shapePos);
         let rawRot = RotationOps.intoRaw(shapeRot);
-        let rawRayOrig = VectorOps.intoRaw(rayOrig);
-        let rawRayDir = VectorOps.intoRaw(rayDir);
+        let rawRayOrig = VectorOps.intoRaw(ray.origin);
+        let rawRayDir = VectorOps.intoRaw(ray.dir);
 
         let rawShape = this.intoRaw();
 
@@ -231,17 +230,16 @@ export abstract class Shape {
     }
 
     castRay(
+        ray: Ray,
         shapePos: Vector,
         shapeRot: Rotation,
-        rayOrig: Vector,
-        rayDir: Vector,
         maxToi: number,
         solid: boolean
     ): number {
         let rawPos = VectorOps.intoRaw(shapePos);
         let rawRot = RotationOps.intoRaw(shapeRot);
-        let rawRayOrig = VectorOps.intoRaw(rayOrig);
-        let rawRayDir = VectorOps.intoRaw(rayDir);
+        let rawRayOrig = VectorOps.intoRaw(ray.origin);
+        let rawRayDir = VectorOps.intoRaw(ray.dir);
 
         let rawShape = this.intoRaw();
 
@@ -263,17 +261,16 @@ export abstract class Shape {
     }
 
     castRayAndGetNormal(
+        ray: Ray,
         shapePos: Vector,
         shapeRot: Rotation,
-        rayOrig: Vector,
-        rayDir: Vector,
         maxToi: number,
         solid: boolean,
     ): RayIntersection {
         let rawPos = VectorOps.intoRaw(shapePos);
         let rawRot = RotationOps.intoRaw(shapeRot);
-        let rawRayOrig = VectorOps.intoRaw(rayOrig);
-        let rawRayDir = VectorOps.intoRaw(rayDir);
+        let rawRayOrig = VectorOps.intoRaw(ray.origin);
+        let rawRayDir = VectorOps.intoRaw(ray.dir);
 
         let rawShape = this.intoRaw();
 

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -158,7 +158,6 @@ export abstract class Shape {
         let rawPos = VectorOps.intoRaw(shapePos);
         let rawRot = RotationOps.intoRaw(shapeRot);
         let rawPoint = VectorOps.intoRaw(point);
-
         let rawShape = this.intoRaw();
 
         let result = rawShape.containsPoint(
@@ -170,6 +169,7 @@ export abstract class Shape {
         rawPos.free();
         rawRot.free();
         rawPoint.free();
+        rawShape.free();
 
         return result;
     }
@@ -183,7 +183,6 @@ export abstract class Shape {
         let rawPos = VectorOps.intoRaw(shapePos);
         let rawRot = RotationOps.intoRaw(shapeRot);
         let rawPoint = VectorOps.intoRaw(point);
-
         let rawShape = this.intoRaw();
 
         let result = PointProjection.fromRaw(rawShape.projectPoint(
@@ -196,6 +195,7 @@ export abstract class Shape {
         rawPos.free();
         rawRot.free();
         rawPoint.free();
+        rawShape.free();
 
         return result;
     }
@@ -210,7 +210,6 @@ export abstract class Shape {
         let rawRot = RotationOps.intoRaw(shapeRot);
         let rawRayOrig = VectorOps.intoRaw(ray.origin);
         let rawRayDir = VectorOps.intoRaw(ray.dir);
-
         let rawShape = this.intoRaw();
 
         let result = rawShape.intersectsRay(
@@ -225,6 +224,7 @@ export abstract class Shape {
         rawRot.free();
         rawRayOrig.free();
         rawRayDir.free();
+        rawShape.free();
 
         return result;
     }
@@ -240,7 +240,6 @@ export abstract class Shape {
         let rawRot = RotationOps.intoRaw(shapeRot);
         let rawRayOrig = VectorOps.intoRaw(ray.origin);
         let rawRayDir = VectorOps.intoRaw(ray.dir);
-
         let rawShape = this.intoRaw();
 
         let result = rawShape.castRay(
@@ -256,6 +255,7 @@ export abstract class Shape {
         rawRot.free();
         rawRayOrig.free();
         rawRayDir.free();
+        rawShape.free();
 
         return result;
     }
@@ -271,7 +271,6 @@ export abstract class Shape {
         let rawRot = RotationOps.intoRaw(shapeRot);
         let rawRayOrig = VectorOps.intoRaw(ray.origin);
         let rawRayDir = VectorOps.intoRaw(ray.dir);
-
         let rawShape = this.intoRaw();
 
         let result = RayIntersection.fromRaw(rawShape.castRayAndGetNormal(
@@ -287,6 +286,7 @@ export abstract class Shape {
         rawRot.free();
         rawRayOrig.free();
         rawRayDir.free();
+        rawShape.free();
 
         return result;
     }


### PR DESCRIPTION
```
castShape
intersectsShape
contactShape
containsPoint
projectPoint
intersectsRay
castRay
castRayAndGetNormal
```

they are on `Collider` before, and now they are on `Shape` too, because these methods are duplicated, so i have 'merged' them into a trait and implemented it on `SharedShape`. please review the changes, thanks.
