### PR TITLE
Fix resetTorques

### DIFF
--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -523,7 +523,7 @@ export class RigidBody {
      * @param wakeUp - should the rigid-body be automatically woken-up?
      */
     public resetTorques(wakeUp: boolean) {
-        this.rawSet.rbResetForces(this.handle, wakeUp);
+        this.rawSet.rbResetTorques(this.handle, wakeUp);
     }
 
     /**


### PR DESCRIPTION
`resetTorques` now invokes the correct function (`rbResetTorques`).

Apologies for the added line break at EOF, this was the doing of GitHub's web-based commit editor... :S