### PR TITLE
Simplify handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,8 +584,7 @@ dependencies = [
 [[package]]
 name = "rapier2d"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c575f233b1c105e17366b9d2edb82ab1bb4c95d55d22741c20e2e1c0aa6932a3"
+source = "git+https://github.com/dimforge/rapier?rev=31cfce4db30efeb15ccb8c51e6c20ff07406987c#31cfce4db30efeb15ccb8c51e6c20ff07406987c"
 dependencies = [
  "approx",
  "arrayvec",
@@ -607,8 +606,7 @@ dependencies = [
 [[package]]
 name = "rapier3d"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652dc538f3b0b0c1ba75aa3f4bdcac8d5132630bce22efd54a7240bdac33108d"
+source = "git+https://github.com/dimforge/rapier?rev=31cfce4db30efeb15ccb8c51e6c20ff07406987c#31cfce4db30efeb15ccb8c51e6c20ff07406987c"
 dependencies = [
  "approx",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "rapier2d"
 version = "0.12.0"
-source = "git+https://github.com/dimforge/rapier?rev=31cfce4db30efeb15ccb8c51e6c20ff07406987c#31cfce4db30efeb15ccb8c51e6c20ff07406987c"
+source = "git+https://github.com/dimforge/rapier?rev=fb1bfc7#fb1bfc762c89cd8c5bd745a82998c1662a1bf196"
 dependencies = [
  "approx",
  "arrayvec",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "rapier3d"
 version = "0.12.0"
-source = "git+https://github.com/dimforge/rapier?rev=31cfce4db30efeb15ccb8c51e6c20ff07406987c#31cfce4db30efeb15ccb8c51e6c20ff07406987c"
+source = "git+https://github.com/dimforge/rapier?rev=fb1bfc7#fb1bfc762c89cd8c5bd745a82998c1662a1bf196"
 dependencies = [
  "approx",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ codegen-units = 1
 #simba = { path = "../simba" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-#rapier2d = { git = "https://github.com/dimforge/rapier", rev = "0ac35e12a7ed8699181550ec1a255917e736e7a4" }
-#rapier3d = { git = "https://github.com/dimforge/rapier", rev = "0ac35e12a7ed8699181550ec1a255917e736e7a4" }
+rapier2d = { git = "https://github.com/dimforge/rapier", rev = "31cfce4db30efeb15ccb8c51e6c20ff07406987c" }
+rapier3d = { git = "https://github.com/dimforge/rapier", rev = "31cfce4db30efeb15ccb8c51e6c20ff07406987c" }
 #parry2d = { git = "https://github.com/dimforge/parry" }
 #parry3d = { git = "https://github.com/dimforge/parry" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ codegen-units = 1
 #simba = { path = "../simba" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-rapier2d = { git = "https://github.com/dimforge/rapier", rev = "31cfce4db30efeb15ccb8c51e6c20ff07406987c" }
-rapier3d = { git = "https://github.com/dimforge/rapier", rev = "31cfce4db30efeb15ccb8c51e6c20ff07406987c" }
+rapier2d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
+rapier3d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
 #parry2d = { git = "https://github.com/dimforge/parry" }
 #parry3d = { git = "https://github.com/dimforge/parry" }

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -35,4 +35,5 @@ palette = "0.6"
 
 [package.metadata.wasm-pack.profile.release]
 # add -g to keep debug symbols
-wasm-opt = ['-O4'] # , '-g']
+wasm-opt = ['-O4']
+#wasm-opt = ['-g']

--- a/rapier2d/typedoc.json
+++ b/rapier2d/typedoc.json
@@ -36,7 +36,7 @@
     "pkg/rapier_wasm2d.d.ts:RawShapeContact",
     "pkg/rapier_wasm2d.d.ts:RawShapeTOI",
     "pkg/rapier_wasm2d.d.ts:RawQueryPipeline",
-    "pkg/rapier_wasm3d.d.ts:RawDeserializedWorld",
-    "pkg/rapier_wasm3d.d.ts:RawDebugRenderPipeline"
+    "pkg/rapier_wasm2d.d.ts:RawDeserializedWorld",
+    "pkg/rapier_wasm2d.d.ts:RawDebugRenderPipeline"
   ]
 }

--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -1,9 +1,9 @@
 import { Rotation, Vector, VectorOps, RotationOps } from "../math";
 import { RawGenericJoint, RawImpulseJointSet, RawRigidBodySet, RawJointAxis } from "../raw";
 import {RigidBody, RigidBodyHandle} from "./rigid_body"
+import {RigidBodySet} from "./rigid_body_set";
 // #if DIM3
 import { Quaternion } from "../math";
-import {RigidBodySet} from "./rigid_body_set";
 // #endif
 
 /**

--- a/src.ts/dynamics/impulse_joint_set.ts
+++ b/src.ts/dynamics/impulse_joint_set.ts
@@ -13,6 +13,8 @@ import {
     // #endif
 } from "./impulse_joint";
 import {IslandManager} from "./island_manager";
+import {RigidBodyHandle} from "./rigid_body";
+import {Collider, ColliderHandle} from "../geometry";
 
 /**
  * A set of joints.
@@ -22,6 +24,7 @@ import {IslandManager} from "./island_manager";
  */
 export class ImpulseJointSet {
     raw: RawImpulseJointSet;
+    private map: Map<ImpulseJointHandle, ImpulseJoint>;
 
     /**
      * Release the WASM memory occupied by this joint set.
@@ -29,10 +32,26 @@ export class ImpulseJointSet {
     public free() {
         this.raw.free();
         this.raw = undefined;
+        this.map.clear();
+        this.map = undefined;
     }
 
     constructor(raw?: RawImpulseJointSet) {
         this.raw = raw || new RawImpulseJointSet();
+        this.map = new Map();
+        // Initialize the map with the existing elements, if any.
+        if (raw) {
+            raw.forEachJointHandle((handle: ImpulseJointHandle) => {
+                this.map.set(handle, ImpulseJoint.newTyped(raw, null, handle));
+            });
+        }
+    }
+
+    /** @internal */
+    public finalizeDeserialization(bodies: RigidBodySet) {
+        for (let joint of this.map.values()) {
+            joint.finalizeDeserialization(bodies);
+        }
     }
 
     /**
@@ -42,34 +61,56 @@ export class ImpulseJointSet {
      * @param desc - The joint's parameters.
      * @param parent1 - The handle of the first rigid-body this joint is attached to.
      * @param parent2 - The handle of the second rigid-body this joint is attached to.
+     * @param wakeUp - Should the attached rigid-bodies be awakened?
      */
     public createJoint(
+        bodies: RigidBodySet,
         desc: JointData,
-        parent1: number,
-        parent2: number
-    ): number {
+        parent1: RigidBodyHandle,
+        parent2: RigidBodyHandle,
+        wakeUp: boolean,
+    ): ImpulseJoint {
         const rawParams = desc.intoRaw();
-        const result = this.raw.createJoint(rawParams, parent1, parent2);
+        const handle = this.raw.createJoint(rawParams, parent1, parent2, wakeUp);
         rawParams.free();
-        return result;
+        let joint = ImpulseJoint.newTyped(this.raw, bodies, handle);
+        this.map.set(handle, joint);
+        return joint;
     }
 
     /**
      * Remove a joint from this set.
      *
      * @param handle - The integer handle of the joint.
-     * @param bodies - The set of rigid-bodies containing the rigid-bodies attached by the removed joint.
-     * @param wake_up - If `true`, the rigid-bodies attached by the removed joint will be woken-up automatically.
+     * @param wakeUp - If `true`, the rigid-bodies attached by the removed joint will be woken-up automatically.
      */
-    public remove(handle: ImpulseJointHandle, islands: IslandManager, bodies: RigidBodySet, wake_up: boolean) {
-        this.raw.remove(handle, islands.raw, bodies.raw, wake_up);
+    public remove(handle: ImpulseJointHandle, wakeUp: boolean) {
+        this.raw.remove(handle, wakeUp);
+        this.unmap(handle);
+    }
+
+    /**
+     * Calls the given closure with the integer handle of each impulse joint attached to this rigid-body.
+     *
+     * @param f - The closure called with the integer handle of each impulse joitn attached to the rigid-body.
+     */
+    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (ImpulseJointHandle) => void) {
+        this.raw.forEachJointAttachedToRigidBody(handle, f);
+    }
+
+    /**
+     * Internal function, do not call directly.
+     * @param handle
+     */
+    public unmap(handle: ImpulseJointHandle) {
+        this.map.delete(handle);
     }
 
     /**
      * The number of joints on this set.
      */
     public len(): number {
-        return this.raw.len();
+        return this.map.size;
     }
 
     /**
@@ -78,7 +119,7 @@ export class ImpulseJointSet {
      * @param handle - The joint handle to check.
      */
     public contains(handle: ImpulseJointHandle): boolean {
-        return this.raw.contains(handle);
+        return this.map.has(handle);
     }
 
     /**
@@ -91,41 +132,45 @@ export class ImpulseJointSet {
      * @param handle - The integer handle of the joint to retrieve.
      */
     public get(handle: ImpulseJointHandle): ImpulseJoint {
-        if (this.raw.contains(handle)) {
-            switch (this.raw.jointType(handle)) {
-                case JointType.Revolute:
-                    return new RevoluteImpulseJoint(this.raw, handle);
-                case JointType.Prismatic:
-                    return new PrismaticImpulseJoint(this.raw, handle);
-                case JointType.Fixed:
-                    return new FixedImpulseJoint(this.raw, handle);
-                // #if DIM3
-                case JointType.Spherical:
-                    return new SphericalImpulseJoint(this.raw, handle);
-                // #endif
-            }
-        } else {
-            return null;
+        return this.map.get(handle);
+    }
+
+    /**
+     * Applies the given closure to each joint contained by this set.
+     *
+     * @param f - The closure to apply.
+     */
+    public forEachJoint(f: (joint: ImpulseJoint) => void) {
+        for (const joint of this.map.values()) {
+            f(joint);
         }
     }
 
     /**
-     * Applies the given closure to each joints contained by this set.
-     *
-     * @param f - The closure to apply.
-     */
-    public forEachJoint(f: (handle: ImpulseJoint) => void) {
-        this.raw.forEachJointHandle((handle: number) => {
-            f(this.get(handle));
-        });
-    }
-
-    /**
-     * Applies the given closure to the handle of each joints contained by this set.
+     * Applies the given closure to the handle of each joint contained by this set.
      *
      * @param f - The closure to apply.
      */
     public forEachJointHandle(f: (handle: ImpulseJointHandle) => void) {
-        this.raw.forEachJointHandle(f);
+        for (const key of this.map.keys())
+            f(key);
+    }
+
+    /**
+     * Gets all handles of the joints in the list.
+     *
+     * @returns joint handle list.
+     */
+    public getAllHandles(): ImpulseJointHandle[] {
+        return Array.from(this.map.keys());
+    }
+
+    /**
+     * Gets all joints in the list.
+     *
+     * @returns joint list.
+     */
+    public getAllJoints(): ImpulseJoint[] {
+        return Array.from(this.map.values());
     }
 }

--- a/src.ts/dynamics/impulse_joint_set.ts
+++ b/src.ts/dynamics/impulse_joint_set.ts
@@ -44,13 +44,12 @@ export class ImpulseJointSet {
      * @param parent2 - The handle of the second rigid-body this joint is attached to.
      */
     public createJoint(
-        bodies: RigidBodySet,
         desc: JointData,
         parent1: number,
         parent2: number
     ): number {
         const rawParams = desc.intoRaw();
-        const result = this.raw.createJoint(bodies.raw, rawParams, parent1, parent2);
+        const result = this.raw.createJoint(rawParams, parent1, parent2);
         rawParams.free();
         return result;
     }

--- a/src.ts/dynamics/impulse_joint_set.ts
+++ b/src.ts/dynamics/impulse_joint_set.ts
@@ -92,9 +92,9 @@ export class ImpulseJointSet {
     /**
      * Calls the given closure with the integer handle of each impulse joint attached to this rigid-body.
      *
-     * @param f - The closure called with the integer handle of each impulse joitn attached to the rigid-body.
+     * @param f - The closure called with the integer handle of each impulse joint attached to the rigid-body.
      */
-    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (ImpulseJointHandle) => void) {
+    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (handle: ImpulseJointHandle) => void) {
         this.raw.forEachJointAttachedToRigidBody(handle, f);
     }
 

--- a/src.ts/dynamics/multibody_joint.ts
+++ b/src.ts/dynamics/multibody_joint.ts
@@ -1,8 +1,15 @@
-import {RawJointAxis, RawMultibodyJointSet} from "../raw";
+import {RawImpulseJointSet, RawJointAxis, RawMultibodyJointSet} from "../raw";
 
 // #if DIM3
 import {Quaternion} from "../math";
-import {MotorModel} from "./impulse_joint";
+import {
+    FixedImpulseJoint,
+    ImpulseJointHandle,
+    JointType,
+    MotorModel,
+    PrismaticImpulseJoint,
+    RevoluteImpulseJoint, SphericalImpulseJoint
+} from "./impulse_joint";
 // #endif
 
 /**
@@ -17,6 +24,23 @@ export class MultibodyJoint {
     constructor(rawSet: RawMultibodyJointSet, handle: MultibodyJointHandle) {
         this.rawSet = rawSet;
         this.handle = handle;
+    }
+
+    public static newTyped(rawSet: RawMultibodyJointSet, handle: MultibodyJointHandle): MultibodyJoint {
+        switch (rawSet.jointType(handle)) {
+            case JointType.Revolute:
+                return new RevoluteMultibodyJoint(rawSet, handle);
+            case JointType.Prismatic:
+                return new PrismaticMultibodyJoint(rawSet, handle);
+            case JointType.Fixed:
+                return new FixedMultibodyJoint(rawSet, handle);
+            // #if DIM3
+            case JointType.Spherical:
+                return new SphericalMultibodyJoint(rawSet, handle);
+            // #endif
+            default:
+                return new MultibodyJoint(rawSet, handle);
+        }
     }
 
     /**

--- a/src.ts/dynamics/multibody_joint.ts
+++ b/src.ts/dynamics/multibody_joint.ts
@@ -1,15 +1,16 @@
 import {RawImpulseJointSet, RawJointAxis, RawMultibodyJointSet} from "../raw";
-
-// #if DIM3
-import {Quaternion} from "../math";
 import {
     FixedImpulseJoint,
     ImpulseJointHandle,
     JointType,
     MotorModel,
     PrismaticImpulseJoint,
-    RevoluteImpulseJoint, SphericalImpulseJoint
+    RevoluteImpulseJoint
 } from "./impulse_joint";
+
+// #if DIM3
+import {Quaternion} from "../math";
+import { SphericalImpulseJoint } from "./impulse_joint";
 // #endif
 
 /**

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -144,7 +144,7 @@ export class MultibodyJointSet {
      *
      * @param f - The closure called with the integer handle of each multibody joint attached to the rigid-body.
      */
-    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (MultibodyJointHandle) => void) {
+    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (handle: MultibodyJointHandle) => void) {
         this.raw.forEachJointAttachedToRigidBody(handle, f);
     }
 

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -11,9 +11,12 @@ import {
     // #endif
 } from "./multibody_joint";
 import {
+    ImpulseJointHandle,
     JointData, JointType
 } from "./impulse_joint";
 import {IslandManager} from "./island_manager";
+import {ColliderHandle} from "../geometry";
+import {RigidBodyHandle} from "./rigid_body";
 
 /**
  * A set of joints.
@@ -23,6 +26,7 @@ import {IslandManager} from "./island_manager";
  */
 export class MultibodyJointSet {
     raw: RawMultibodyJointSet;
+    private map: Map<MultibodyJointHandle, MultibodyJoint>
 
     /**
      * Release the WASM memory occupied by this joint set.
@@ -30,48 +34,68 @@ export class MultibodyJointSet {
     public free() {
         this.raw.free();
         this.raw = undefined;
+        this.map.clear();
+        this.map = undefined;
     }
 
     constructor(raw?: RawMultibodyJointSet) {
         this.raw = raw || new RawMultibodyJointSet();
+        this.map = new Map();
+        // Initialize the map with the existing elements, if any.
+        if (raw) {
+            raw.forEachJointHandle((handle: MultibodyJointHandle) => {
+                this.map.set(handle, MultibodyJoint.newTyped(this.raw, handle));
+            });
+        }
     }
 
     /**
      * Creates a new joint and return its integer handle.
      *
-     * @param bodies - The set of rigid-bodies containing the bodies the joint is attached to.
      * @param desc - The joint's parameters.
      * @param parent1 - The handle of the first rigid-body this joint is attached to.
      * @param parent2 - The handle of the second rigid-body this joint is attached to.
+     * @param wakeUp - Should the attached rigid-bodies be awakened?
      */
     public createJoint(
         desc: JointData,
-        parent1: number,
-        parent2: number
-    ): number {
+        parent1: RigidBodyHandle,
+        parent2: RigidBodyHandle,
+        wakeUp: boolean,
+    ): MultibodyJoint {
         const rawParams = desc.intoRaw();
-        const result = this.raw.createJoint(rawParams, parent1, parent2);
+        const handle = this.raw.createJoint(rawParams, parent1, parent2, wakeUp);
         rawParams.free();
-        return result;
+        let joint = MultibodyJoint.newTyped(this.raw, handle);
+        this.map.set(handle, joint);
+        return joint;
     }
 
     /**
      * Remove a joint from this set.
      *
      * @param handle - The integer handle of the joint.
-     * @param bodies - The set of rigid-bodies containing the rigid-bodies attached by the removed joint.
      * @param wake_up - If `true`, the rigid-bodies attached by the removed joint will be woken-up automatically.
      */
-    public remove(handle: MultibodyJointHandle, islands: IslandManager, bodies: RigidBodySet, wake_up: boolean) {
-        this.raw.remove(handle, islands.raw, bodies.raw, wake_up);
+    public remove(handle: MultibodyJointHandle, wake_up: boolean) {
+        this.raw.remove(handle, wake_up);
+        this.map.delete(handle);
     }
 
-    // /**
-    //  * The number of joints on this set.
-    //  */
-    // public len(): number {
-    //     return this.raw.len();
-    // }
+    /**
+     * Internal function, do not call directly.
+     * @param handle
+     */
+    public unmap(handle: MultibodyJointHandle) {
+        this.map.delete(handle);
+    }
+
+    /**
+     * The number of joints on this set.
+     */
+    public len(): number {
+        return this.map.size;
+    }
 
     /**
      * Does this set contain a joint with the given handle?
@@ -79,7 +103,7 @@ export class MultibodyJointSet {
      * @param handle - The joint handle to check.
      */
     public contains(handle: MultibodyJointHandle): boolean {
-        return this.raw.contains(handle);
+        return this.map.has(handle);
     }
 
     /**
@@ -92,41 +116,53 @@ export class MultibodyJointSet {
      * @param handle - The integer handle of the joint to retrieve.
      */
     public get(handle: MultibodyJointHandle): MultibodyJoint {
-        if (this.raw.contains(handle)) {
-            switch (this.raw.jointType(handle)) {
-                case JointType.Revolute:
-                    return new RevoluteMultibodyJoint(this.raw, handle);
-                case JointType.Prismatic:
-                    return new PrismaticMultibodyJoint(this.raw, handle);
-                case JointType.Fixed:
-                    return new FixedMultibodyJoint(this.raw, handle);
-                // #if DIM3
-                case JointType.Spherical:
-                    return new SphericalMultibodyJoint(this.raw, handle);
-                // #endif
-            }
-        } else {
-            return null;
-        }
+        return this.map.get(handle);
     }
 
     /**
-     * Applies the given closure to each joints contained by this set.
+     * Applies the given closure to each joint contained by this set.
      *
      * @param f - The closure to apply.
      */
-    public forEachJoint(f: (handle: MultibodyJoint) => void) {
-        this.raw.forEachJointHandle((handle: number) => {
-            f(this.get(handle));
-        });
+    public forEachJoint(f: (joint: MultibodyJoint) => void) {
+        for (const joint of this.map.values())
+            f(joint);
     }
 
     /**
-     * Applies the given closure to the handle of each joints contained by this set.
+     * Applies the given closure to the handle of each joint contained by this set.
      *
      * @param f - The closure to apply.
      */
     public forEachJointHandle(f: (handle: MultibodyJointHandle) => void) {
-        this.raw.forEachJointHandle(f);
+        for (const key of this.map.keys())
+            f(key);
+    }
+
+    /**
+     * Calls the given closure with the integer handle of each multibody joint attached to this rigid-body.
+     *
+     * @param f - The closure called with the integer handle of each multibody joint attached to the rigid-body.
+     */
+    public forEachJointHandleAttachedToRigidBody(handle: RigidBodyHandle, f: (MultibodyJointHandle) => void) {
+        this.raw.forEachJointAttachedToRigidBody(handle, f);
+    }
+
+    /**
+     * Gets all handles of the joints in the list.
+     *
+     * @returns joint handle list.
+     */
+    public getAllHandles(): MultibodyJointHandle[] {
+        return Array.from(this.map.keys());
+    }
+
+    /**
+     * Gets all joints in the list.
+     *
+     * @returns joint list.
+     */
+    public getAllJoints(): MultibodyJoint[] {
+        return Array.from(this.map.values());
     }
 }

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -45,13 +45,12 @@ export class MultibodyJointSet {
      * @param parent2 - The handle of the second rigid-body this joint is attached to.
      */
     public createJoint(
-        bodies: RigidBodySet,
         desc: JointData,
         parent1: number,
         parent2: number
     ): number {
         const rawParams = desc.intoRaw();
-        const result = this.raw.createJoint(bodies.raw, rawParams, parent1, parent2);
+        const result = this.raw.createJoint(rawParams, parent1, parent2);
         rawParams.free();
         return result;
     }

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -1,6 +1,6 @@
 import { RawRigidBodySet } from "../raw"
 import { Rotation, RotationOps, Vector, VectorOps } from '../math';
-import { ColliderHandle } from "../geometry";
+import {Collider, ColliderHandle, ColliderSet} from "../geometry";
 
 /**
  * The integer identifier of a collider added to a `ColliderSet`.
@@ -45,6 +45,7 @@ export enum RigidBodyType {
  */
 export class RigidBody {
     private rawSet: RawRigidBodySet; // The RigidBody won't need to free this.
+    private colliderSet: ColliderSet;
     readonly handle: RigidBodyHandle;
     
     /**
@@ -52,9 +53,15 @@ export class RigidBody {
      */
     public userData?: unknown;
 
-    constructor(rawSet: RawRigidBodySet, handle: RigidBodyHandle) {
+    constructor(rawSet: RawRigidBodySet, colliderSet: ColliderSet, handle: RigidBodyHandle) {
         this.rawSet = rawSet;
+        this.colliderSet = colliderSet;
         this.handle = handle;
+    }
+
+    /** @internal */
+    public finalizeDeserialization(colliderSet: ColliderSet) {
+        this.colliderSet = colliderSet;
     }
 
     /**
@@ -417,13 +424,13 @@ export class RigidBody {
     }
 
     /**
-     * Retrieves the handle of the `i-th` collider attached to this rigid-body.
+     * Retrieves the `i-th` collider attached to this rigid-body.
      *
      * @param i - The index of the collider to retrieve. Must be a number in `[0, this.numColliders()[`.
      *         This index is **not** the same as the unique identifier of the collider.
      */
-    public collider(i: number): ColliderHandle {
-        return this.rawSet.rbCollider(this.handle, i);
+    public collider(i: number): Collider {
+        return this.colliderSet.get(this.rawSet.rbCollider(this.handle, i));
     }
 
 

--- a/src.ts/geometry/point.ts
+++ b/src.ts/geometry/point.ts
@@ -1,7 +1,8 @@
-import { ColliderHandle } from "./collider";
+import {Collider, ColliderHandle} from "./collider";
 import { Vector, VectorOps } from "../math";
 import { RawPointColliderProjection, RawPointProjection } from "../raw";
 import { FeatureType } from "./feature";
+import {ColliderSet} from "./collider_set";
 
 
 /**
@@ -40,9 +41,9 @@ export class PointProjection {
  */
 export class PointColliderProjection {
     /**
-     * The handle of the collider hit by the ray.
+     * The collider hit by the ray.
      */
-    colliderHandle: ColliderHandle
+    collider: Collider
     /**
      * The projection of the point on the collider.
      */
@@ -62,8 +63,8 @@ export class PointColliderProjection {
      */
     featureId: number | undefined = undefined;
 
-    constructor(colliderHandle: ColliderHandle, point: Vector, isInside: boolean, featureType?: FeatureType, featureId?: number) {
-        this.colliderHandle = colliderHandle;
+    constructor(collider: Collider, point: Vector, isInside: boolean, featureType?: FeatureType, featureId?: number) {
+        this.collider = collider;
         this.point = point;
         this.isInside = isInside;
         if (featureId !== undefined)
@@ -72,12 +73,12 @@ export class PointColliderProjection {
             this.featureType = featureType;
     }
 
-    public static fromRaw(raw: RawPointColliderProjection): PointColliderProjection {
+    public static fromRaw(colliderSet: ColliderSet, raw: RawPointColliderProjection): PointColliderProjection {
         if (!raw)
             return null;
 
         const result = new PointColliderProjection(
-            raw.colliderHandle(),
+            colliderSet.get(raw.colliderHandle()),
             VectorOps.fromRaw(raw.point()),
             raw.isInside(),
             raw.featureType(),

--- a/src.ts/geometry/ray.ts
+++ b/src.ts/geometry/ray.ts
@@ -1,7 +1,8 @@
 import { Vector, VectorOps } from "../math";
 import { RawRayColliderIntersection, RawRayColliderToi, RawRayIntersection } from "../raw";
-import { ColliderHandle } from "./collider";
+import { Collider } from "./collider";
 import { FeatureType } from "./feature";
+import {ColliderSet} from "./collider_set";
 
 /**
  * A ray. This is a directed half-line.
@@ -93,9 +94,9 @@ export class RayIntersection {
  */
 export class RayColliderIntersection {
     /**
-     * The handle of the collider hit by the ray.
+     * The collider hit by the ray.
      */
-    colliderHandle: ColliderHandle
+    collider: Collider
     /**
      * The time-of-impact of the ray with the collider.
      *
@@ -117,8 +118,8 @@ export class RayColliderIntersection {
      */
     featureId: number | undefined = undefined;
 
-    constructor(colliderHandle: ColliderHandle, toi: number, normal: Vector, featureType?: FeatureType, featureId?: number) {
-        this.colliderHandle = colliderHandle;
+    constructor(collider: Collider, toi: number, normal: Vector, featureType?: FeatureType, featureId?: number) {
+        this.collider = collider;
         this.toi = toi;
         this.normal = normal;
         if (featureId !== undefined)
@@ -127,12 +128,12 @@ export class RayColliderIntersection {
             this.featureType = featureType;
     }
 
-    public static fromRaw(raw: RawRayColliderIntersection): RayColliderIntersection {
+    public static fromRaw(colliderSet: ColliderSet, raw: RawRayColliderIntersection): RayColliderIntersection {
         if (!raw)
             return null;
 
         const result = new RayColliderIntersection(
-            raw.colliderHandle(),
+            colliderSet.get(raw.colliderHandle()),
             raw.toi(),
             VectorOps.fromRaw(raw.normal()),
             raw.featureType(),
@@ -150,7 +151,7 @@ export class RayColliderToi {
     /**
      * The handle of the collider hit by the ray.
      */
-    colliderHandle: ColliderHandle
+    collider: Collider
     /**
      * The time-of-impact of the ray with the collider.
      *
@@ -158,17 +159,17 @@ export class RayColliderToi {
      */
     toi: number
 
-    constructor(colliderHandle: ColliderHandle, toi: number) {
-        this.colliderHandle = colliderHandle;
+    constructor(collider: Collider, toi: number) {
+        this.collider = collider;
         this.toi = toi;
     }
 
-    public static fromRaw(raw: RawRayColliderToi): RayColliderToi {
+    public static fromRaw(colliderSet: ColliderSet, raw: RawRayColliderToi): RayColliderToi {
         if (!raw)
             return null;
 
         const result = new RayColliderToi(
-            raw.colliderHandle(),
+            colliderSet.get(raw.colliderHandle()),
             raw.toi(),
         );
         raw.free();

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -193,7 +193,7 @@ export abstract class Shape {
         let rawShape1 = this.intoRaw();
         let rawShape2 = shape2.intoRaw();
 
-        let result = ShapeTOI.fromRaw(rawShape1.castShape(
+        let result = ShapeTOI.fromRaw(null, rawShape1.castShape(
             rawPos1,
             rawRot1,
             rawVel1,

--- a/src.ts/geometry/toi.ts
+++ b/src.ts/geometry/toi.ts
@@ -1,6 +1,7 @@
-import {ColliderHandle} from "./collider";
+import {Collider} from "./collider";
 import {Vector, VectorOps} from "../math";
 import {RawShapeTOI, RawShapeColliderTOI} from "../raw";
+import {ColliderSet} from "./collider_set";
 
 /**
  * The intersection between a ray and a collider.
@@ -39,7 +40,7 @@ export class ShapeTOI {
         this.normal2 = normal2;
     }
 
-    public static fromRaw(raw: RawShapeTOI): ShapeTOI {
+    public static fromRaw(colliderSet: ColliderSet, raw: RawShapeTOI): ShapeTOI {
         if (!raw)
             return null;
 
@@ -62,19 +63,19 @@ export class ShapeTOI {
     /**
      * The handle of the collider hit by the ray.
      */
-    colliderHandle: ColliderHandle
+    collider: Collider
     
-    constructor(colliderHandle: ColliderHandle, toi: number, witness1: Vector, witness2: Vector, normal1: Vector, normal2: Vector) {
+    constructor(collider: Collider, toi: number, witness1: Vector, witness2: Vector, normal1: Vector, normal2: Vector) {
         super(toi, witness1, witness2, normal1, normal2);
-        this.colliderHandle = colliderHandle;
+        this.collider = collider;
     }
 
-    public static fromRaw(raw: RawShapeColliderTOI): ShapeColliderTOI {
+    public static fromRaw(colliderSet: ColliderSet, raw: RawShapeColliderTOI): ShapeColliderTOI {
         if (!raw)
             return null;
 
         const result = new ShapeColliderTOI(
-            raw.colliderHandle(),
+            colliderSet.get(raw.colliderHandle()),
             raw.toi(),
             VectorOps.fromRaw(raw.witness1()),
             VectorOps.fromRaw(raw.witness2()),

--- a/src.ts/pipeline/debug_render_pipeline.ts
+++ b/src.ts/pipeline/debug_render_pipeline.ts
@@ -56,8 +56,8 @@ export class DebugRenderPipeline {
         this.raw = raw || new RawDebugRenderPipeline();
     }
 
-    public render(bodies: RigidBodySet, colliders: ColliderSet, impulse_joints: ImpulseJointSet, multibody_joints: MultibodyJointSet) {
-        this.raw.render(bodies.raw, colliders.raw, impulse_joints.raw, multibody_joints.raw);
+    public render(bodies: RigidBodySet, colliders: ColliderSet, impulse_joints: ImpulseJointSet, multibody_joints: MultibodyJointSet, narrow_phase: NarrowPhase) {
+        this.raw.render(bodies.raw, colliders.raw, impulse_joints.raw, multibody_joints.raw, narrow_phase.raw);
         this.vertices = this.raw.vertices();
         this.colors = this.raw.colors();
     }

--- a/src.ts/pipeline/event_queue.ts
+++ b/src.ts/pipeline/event_queue.ts
@@ -1,6 +1,6 @@
 import { RawEventQueue } from '../raw'
 import { RigidBodyHandle } from '../dynamics'
-import { ColliderHandle } from '../geometry'
+import {Collider, ColliderHandle} from '../geometry'
 
 /// Flags indicating what events are enabled for colliders.
 export enum ActiveEvents {

--- a/src.ts/pipeline/query_pipeline.ts
+++ b/src.ts/pipeline/query_pipeline.ts
@@ -63,7 +63,7 @@ export class QueryPipeline {
     ): RayColliderToi | null {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
-        let result = RayColliderToi.fromRaw(this.raw.castRay(
+        let result = RayColliderToi.fromRaw(colliders, this.raw.castRay(
             colliders.raw,
             rawOrig,
             rawDir,
@@ -103,7 +103,7 @@ export class QueryPipeline {
     ): RayColliderIntersection | null {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
-        let result = RayColliderIntersection.fromRaw(this.raw.castRayAndGetNormal(
+        let result = RayColliderIntersection.fromRaw(colliders, this.raw.castRayAndGetNormal(
             colliders.raw,
             rawOrig,
             rawDir,
@@ -146,7 +146,7 @@ export class QueryPipeline {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
         let rawCallback = (rawInter: RawRayColliderIntersection) => {
-            return callback(RayColliderIntersection.fromRaw(rawInter));
+            return callback(RayColliderIntersection.fromRaw(colliders, rawInter));
         };
 
         this.raw.intersectionsWithRay(
@@ -222,7 +222,7 @@ export class QueryPipeline {
         filter?: (collider: ColliderHandle) => boolean
     ): PointColliderProjection | null {
         let rawPoint = VectorOps.intoRaw(point);
-        let result = PointColliderProjection.fromRaw(this.raw.projectPoint(
+        let result = PointColliderProjection.fromRaw(colliders, this.raw.projectPoint(
             colliders.raw,
             rawPoint,
             solid,
@@ -249,7 +249,7 @@ export class QueryPipeline {
         groups: InteractionGroups,
     ): PointColliderProjection | null {
         let rawPoint = VectorOps.intoRaw(point);
-        let result = PointColliderProjection.fromRaw(this.raw.projectPointAndGetFeature(
+        let result = PointColliderProjection.fromRaw(colliders, this.raw.projectPointAndGetFeature(
             colliders.raw,
             rawPoint,
             groups,
@@ -320,7 +320,7 @@ export class QueryPipeline {
         let rawVel = VectorOps.intoRaw(shapeVel);
         let rawShape = shape.intoRaw();
 
-        let result = ShapeColliderTOI.fromRaw(this.raw.castShape(
+        let result = ShapeColliderTOI.fromRaw(colliders, this.raw.castShape(
             colliders.raw,
             rawPos,
             rawRot,

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -125,6 +125,10 @@ export class World {
         this.physicsPipeline = new PhysicsPipeline(rawPhysicsPipeline);
         this.serializationPipeline = new SerializationPipeline(rawSerializationPipeline);
         this.debugRenderPipeline = new DebugRenderPipeline(rawDebugRenderPipeline);
+
+        this.impulseJoints.finalizeDeserialization(this.bodies);
+        this.bodies.finalizeDeserialization(this.colliders);
+        this.colliders.finalizeDeserialization(this.bodies);
     }
 
     public static fromRaw(raw: RawDeserializedWorld): World {
@@ -178,7 +182,7 @@ export class World {
      * Computes all the lines (and their colors) needed to render the scene.
      */
     public debugRender(): DebugRenderBuffers {
-        this.debugRenderPipeline.render(this.bodies, this.colliders, this.impulseJoints, this.multibodyJoints);
+        this.debugRenderPipeline.render(this.bodies, this.colliders, this.impulseJoints, this.multibodyJoints, this.narrowPhase);
         return new DebugRenderBuffers(this.debugRenderPipeline.vertices, this.debugRenderPipeline.colors);
     }
 
@@ -293,17 +297,18 @@ export class World {
      * @param body - The description of the rigid-body to create.
      */
     public createRigidBody(body: RigidBodyDesc): RigidBody {
-        return this.bodies.get(this.bodies.createRigidBody(body));
+        return this.bodies.createRigidBody(this.colliders, body);
     }
 
     /**
      * Creates a new collider.
      *
      * @param desc - The description of the collider.
-     * @param parentHandle - The handle of the rigid-body this collider is attached to.
+     * @param parent - The rigid-body this collider is attached to.
      */
-    public createCollider(desc: ColliderDesc, parentHandle?: RigidBodyHandle): Collider {
-        return this.colliders.get(this.colliders.createCollider(this.bodies, desc, parentHandle));
+    public createCollider(desc: ColliderDesc, parent?: RigidBody): Collider {
+        let parentHandle = parent ? parent.handle : undefined;
+        return this.colliders.createCollider(this.bodies, desc, parentHandle);
     }
 
     /**
@@ -312,15 +317,15 @@ export class World {
      * @param params - The description of the joint to create.
      * @param parent1 - The first rigid-body attached to this joint.
      * @param parent2 - The second rigid-body attached to this joint.
+     * @param wakeUp - Should the attached rigid-bodies be awakened?
      */
     public createImpulseJoint(
         params: JointData,
         parent1: RigidBody,
-        parent2: RigidBody
+        parent2: RigidBody,
+        wakeUp: boolean,
     ): ImpulseJoint {
-        return this.impulseJoints.get(
-            this.impulseJoints.createJoint(params, parent1.handle, parent2.handle)
-        );
+        return this.impulseJoints.createJoint(this.bodies, params, parent1.handle, parent2.handle, wakeUp);
     }
 
     /**
@@ -329,15 +334,15 @@ export class World {
      * @param params - The description of the joint to create.
      * @param parent1 - The first rigid-body attached to this joint.
      * @param parent2 - The second rigid-body attached to this joint.
+     * @param wakeUp - Should the attached rigid-bodies be awakened?
      */
     public createMultibodyJoint(
         params: JointData,
         parent1: RigidBody,
-        parent2: RigidBody
+        parent2: RigidBody,
+        wakeUp: boolean,
     ): MultibodyJoint {
-        return this.multibodyJoints.get(
-            this.multibodyJoints.createJoint(params, parent1.handle, parent2.handle)
-        );
+        return this.multibodyJoints.createJoint(params, parent1.handle, parent2.handle, wakeUp);
     }
 
     /**
@@ -423,8 +428,6 @@ export class World {
         if (this.impulseJoints) {
             this.impulseJoints.remove(
                 joint.handle,
-                this.islands,
-                this.bodies,
                 wakeUp,
             );
         }
@@ -440,8 +443,6 @@ export class World {
         if (this.impulseJoints) {
             this.multibodyJoints.remove(
                 joint.handle,
-                this.islands,
-                this.bodies,
                 wakeUp,
             );
         }
@@ -528,9 +529,9 @@ export class World {
         maxToi: number,
         solid: boolean,
         groups: InteractionGroups,
-        filter?: (collider: ColliderHandle) => boolean
+        filter?: (collider: Collider) => boolean
     ): RayColliderToi | null {
-        return this.queryPipeline.castRay(this.colliders, ray, maxToi, solid, groups, filter);
+        return this.queryPipeline.castRay(this.colliders, ray, maxToi, solid, groups, castClosure(this.colliders, filter));
     }
 
     /**
@@ -550,9 +551,9 @@ export class World {
         maxToi: number,
         solid: boolean,
         groups: InteractionGroups,
-        filter?: (collider: ColliderHandle) => boolean
+        filter?: (collider: Collider) => boolean
     ): RayColliderIntersection | null {
-        return this.queryPipeline.castRayAndGetNormal(this.colliders, ray, maxToi, solid, groups, filter);
+        return this.queryPipeline.castRayAndGetNormal(this.colliders, ray, maxToi, solid, groups, castClosure(this.colliders, filter));
     }
 
 
@@ -575,9 +576,9 @@ export class World {
         solid: boolean,
         groups: InteractionGroups,
         callback: (intersect: RayColliderIntersection) => boolean,
-        filter?: (collider: ColliderHandle) => boolean
+        filter?: (collider: Collider) => boolean
     ) {
-        this.queryPipeline.intersectionsWithRay(this.colliders, ray, maxToi, solid, groups, callback, filter)
+        this.queryPipeline.intersectionsWithRay(this.colliders, ray, maxToi, solid, groups, callback, castClosure(this.colliders, filter))
     }
 
     /**
@@ -594,9 +595,10 @@ export class World {
         shapeRot: Rotation,
         shape: Shape,
         groups: InteractionGroups,
-        filter?: (collider: ColliderHandle) => boolean
-    ): ColliderHandle | null {
-        return this.queryPipeline.intersectionWithShape(this.colliders, shapePos, shapeRot, shape, groups, filter);
+        filter?: (collider: Collider) => boolean
+    ): Collider | null {
+        let handle = this.queryPipeline.intersectionWithShape(this.colliders, shapePos, shapeRot, shape, groups, castClosure(this.colliders, filter));
+        return (handle != null) ? this.colliders.get(handle) : null;
     }
 
     /**
@@ -615,9 +617,9 @@ export class World {
         point: Vector,
         solid: boolean,
         groups: InteractionGroups,
-        filter?: (collider: ColliderHandle) => boolean
+        filter?: (collider: Collider) => boolean
     ): PointColliderProjection | null {
-        return this.queryPipeline.projectPoint(this.colliders, point, solid, groups, filter);
+        return this.queryPipeline.projectPoint(this.colliders, point, solid, groups, castClosure(this.colliders, filter));
     }
 
     /**
@@ -646,10 +648,10 @@ export class World {
     public intersectionsWithPoint(
         point: Vector,
         groups: InteractionGroups,
-        callback: (handle: ColliderHandle) => boolean,
-        filter?: (collider: ColliderHandle) => boolean
+        callback: (handle: Collider) => boolean,
+        filter?: (collider: Collider) => boolean
     ) {
-        this.queryPipeline.intersectionsWithPoint(this.colliders, point, groups, callback, filter);
+        this.queryPipeline.intersectionsWithPoint(this.colliders, point, groups, castClosure(this.colliders, callback), castClosure(this.colliders, filter));
     }
 
     /**
@@ -673,9 +675,9 @@ export class World {
         shape: Shape,
         maxToi: number,
         groups: InteractionGroups,
-        filter?: (collider: ColliderHandle) => boolean
+        filter?: (collider: Collider) => boolean
     ): ShapeColliderTOI | null {
-        return this.queryPipeline.castShape(this.colliders, shapePos, shapeRot, shapeVel, shape, maxToi, groups, filter);
+        return this.queryPipeline.castShape(this.colliders, shapePos, shapeRot, shapeVel, shape, maxToi, groups, castClosure(this.colliders, filter));
     }
 
     /**
@@ -693,10 +695,10 @@ export class World {
         shapeRot: Rotation,
         shape: Shape,
         groups: InteractionGroups,
-        callback: (handle: ColliderHandle) => boolean,
-        filter?: (collider: ColliderHandle) => boolean
+        callback: (handle: Collider) => boolean,
+        filter?: (collider: Collider) => boolean
     ) {
-        this.queryPipeline.intersectionsWithShape(this.colliders, shapePos, shapeRot, shape, groups, callback, filter);
+        this.queryPipeline.intersectionsWithShape(this.colliders, shapePos, shapeRot, shape, groups, castClosure(this.colliders, callback), castClosure(this.colliders, filter));
     }
 
     /**
@@ -710,9 +712,9 @@ export class World {
     public collidersWithAabbIntersectingAabb(
         aabbCenter: Vector,
         aabbHalfExtents: Vector,
-        callback: (handle: ColliderHandle) => boolean
+        callback: (handle: Collider) => boolean
     ) {
-        this.queryPipeline.collidersWithAabbIntersectingAabb(aabbCenter, aabbHalfExtents, callback);
+        this.queryPipeline.collidersWithAabbIntersectingAabb(aabbCenter, aabbHalfExtents, castClosure(this.colliders, callback));
     }
 
     /**
@@ -721,16 +723,16 @@ export class World {
      * @param collider1 - The second collider involved in the contact.
      * @param f - Closure that will be called on each collider that is in contact with `collider1`.
      */
-    public contactsWith(collider1: ColliderHandle, f: (collider2: ColliderHandle) => void) {
-        this.narrowPhase.contactsWith(collider1, f);
+    public contactsWith(collider1: Collider, f: (collider2: Collider) => void) {
+        this.narrowPhase.contactsWith(collider1.handle, castClosure(this.colliders, f));
     }
 
     /**
      * Enumerates all the colliders intersecting the given colliders, assuming one of them
      * is a sensor.
      */
-    public intersectionsWith(collider1: ColliderHandle, f: (collider2: ColliderHandle) => void) {
-        this.narrowPhase.intersectionsWith(collider1, f);
+    public intersectionsWith(collider1: Collider, f: (collider2: Collider) => void) {
+        this.narrowPhase.intersectionsWith(collider1.handle, castClosure(this.colliders, f));
     }
 
     /**
@@ -742,8 +744,8 @@ export class World {
      *            passed to this closure is `true`, then the contact manifold data is flipped, i.e., methods like `localNormal1`
      *            actually apply to the `collider2` and fields like `localNormal2` apply to the `collider1`.
      */
-    public contactPair(collider1: ColliderHandle, collider2: ColliderHandle, f: (manifold: TempContactManifold, flipped: boolean) => void) {
-        this.narrowPhase.contactPair(collider1, collider2, f);
+    public contactPair(collider1: Collider, collider2: Collider, f: (manifold: TempContactManifold, flipped: boolean) => void) {
+        this.narrowPhase.contactPair(collider1.handle, collider2.handle, f);
     }
 
     /**
@@ -751,7 +753,17 @@ export class World {
      * @param collider1 − The first collider involved in the intersection.
      * @param collider2 − The second collider involved in the intersection.
      */
-    public intersectionPair(collider1: ColliderHandle, collider2: ColliderHandle): boolean {
-        return this.narrowPhase.intersectionPair(collider1, collider2);
+    public intersectionPair(collider1: Collider, collider2: Collider): boolean {
+        return this.narrowPhase.intersectionPair(collider1.handle, collider2.handle);
     }
+}
+
+function castClosure<Res>(set: ColliderSet, f?: (collider :Collider) => Res): (ColliderHandle) => Res | undefined {
+    return handle => {
+        if (!!f) {
+            return f(set.get(handle));
+        } else {
+            return undefined;
+        }
+    };
 }

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -319,7 +319,7 @@ export class World {
         parent2: RigidBody
     ): ImpulseJoint {
         return this.impulseJoints.get(
-            this.impulseJoints.createJoint(this.bodies, params, parent1.handle, parent2.handle)
+            this.impulseJoints.createJoint(params, parent1.handle, parent2.handle)
         );
     }
 
@@ -336,7 +336,7 @@ export class World {
         parent2: RigidBody
     ): MultibodyJoint {
         return this.multibodyJoints.get(
-            this.multibodyJoints.createJoint(this.bodies, params, parent1.handle, parent2.handle)
+            this.multibodyJoints.createJoint(params, parent1.handle, parent2.handle)
         );
     }
 

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -758,7 +758,7 @@ export class World {
     }
 }
 
-function castClosure<Res>(set: ColliderSet, f?: (collider :Collider) => Res): (ColliderHandle) => Res | undefined {
+function castClosure<Res>(set: ColliderSet, f?: (collider :Collider) => Res): (handle: ColliderHandle) => Res | undefined {
     return handle => {
         if (!!f) {
             return f(set.get(handle));

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -1,32 +1,33 @@
 use crate::dynamics::{RawImpulseJointSet, RawJointAxis, RawJointType, RawMotorModel};
 use crate::math::{RawRotation, RawVector};
+use crate::utils::{self, FlatHandle};
 use rapier::dynamics::JointAxis;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 impl RawImpulseJointSet {
     /// The type of this joint.
-    pub fn jointType(&self, handle: u32) -> RawJointType {
+    pub fn jointType(&self, handle: FlatHandle) -> RawJointType {
         self.map(handle, |j| j.data.locked_axes.into())
     }
 
     /// The unique integer identifier of the first rigid-body this joint it attached to.
-    pub fn jointBodyHandle1(&self, handle: u32) -> u32 {
-        self.map(handle, |j| j.body1.into_raw_parts().0)
+    pub fn jointBodyHandle1(&self, handle: FlatHandle) -> FlatHandle {
+        self.map(handle, |j| utils::fuse_handle(j.body1.0))
     }
 
     /// The unique integer identifier of the second rigid-body this joint is attached to.
-    pub fn jointBodyHandle2(&self, handle: u32) -> u32 {
-        self.map(handle, |j| j.body2.into_raw_parts().0)
+    pub fn jointBodyHandle2(&self, handle: FlatHandle) -> FlatHandle {
+        self.map(handle, |j| utils::fuse_handle(j.body2.0))
     }
 
     /// The angular part of the joint’s local frame relative to the first rigid-body it is attached to.
-    pub fn jointFrameX1(&self, handle: u32) -> RawRotation {
+    pub fn jointFrameX1(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |j| j.data.local_frame1.rotation.into())
     }
 
     /// The angular part of the joint’s local frame relative to the second rigid-body it is attached to.
-    pub fn jointFrameX2(&self, handle: u32) -> RawRotation {
+    pub fn jointFrameX2(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |j| j.data.local_frame2.rotation.into())
     }
 
@@ -34,7 +35,7 @@ impl RawImpulseJointSet {
     ///
     /// The first anchor gives the position of the points application point on the
     /// local frame of the first rigid-body it is attached to.
-    pub fn jointAnchor1(&self, handle: u32) -> RawVector {
+    pub fn jointAnchor1(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |j| j.data.local_frame1.translation.vector.into())
     }
 
@@ -42,30 +43,30 @@ impl RawImpulseJointSet {
     ///
     /// The second anchor gives the position of the points application point on the
     /// local frame of the second rigid-body it is attached to.
-    pub fn jointAnchor2(&self, handle: u32) -> RawVector {
+    pub fn jointAnchor2(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |j| j.data.local_frame2.translation.vector.into())
     }
 
     /// Are the limits for this joint enabled?
-    pub fn jointLimitsEnabled(&self, handle: u32, axis: RawJointAxis) -> bool {
+    pub fn jointLimitsEnabled(&self, handle: FlatHandle, axis: RawJointAxis) -> bool {
         self.map(handle, |j| {
             j.data.limit_axes.contains(JointAxis::from(axis).into())
         })
     }
 
     /// Return the lower limit along the given joint axis.
-    pub fn jointLimitsMin(&self, handle: u32, axis: RawJointAxis) -> f32 {
+    pub fn jointLimitsMin(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].min)
     }
 
     /// If this is a prismatic joint, returns its upper limit.
-    pub fn jointLimitsMax(&self, handle: u32, axis: RawJointAxis) -> f32 {
+    pub fn jointLimitsMax(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].max)
     }
 
     pub fn jointConfigureMotorModel(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         axis: RawJointAxis,
         model: RawMotorModel,
     ) {
@@ -78,7 +79,7 @@ impl RawImpulseJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotorVelocity(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         vx: f32,
         vy: f32,
         vz: f32,
@@ -95,7 +96,7 @@ impl RawImpulseJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotorPosition(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         qw: f32,
         qx: f32,
         qy: f32,
@@ -118,7 +119,7 @@ impl RawImpulseJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotor(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         qw: f32,
         qx: f32,
         qy: f32,
@@ -145,7 +146,7 @@ impl RawImpulseJointSet {
 
     pub fn jointConfigureMotorVelocity(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         axis: RawJointAxis,
         targetVel: f32,
         factor: f32,
@@ -155,7 +156,7 @@ impl RawImpulseJointSet {
 
     pub fn jointConfigureMotorPosition(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         axis: RawJointAxis,
         targetPos: f32,
         stiffness: f32,
@@ -166,7 +167,7 @@ impl RawImpulseJointSet {
 
     pub fn jointConfigureMotor(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         axis: RawJointAxis,
         targetPos: f32,
         targetVel: f32,

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -13,12 +13,12 @@ impl RawImpulseJointSet {
 
     /// The unique integer identifier of the first rigid-body this joint it attached to.
     pub fn jointBodyHandle1(&self, handle: FlatHandle) -> FlatHandle {
-        self.map(handle, |j| utils::fuse_handle(j.body1.0))
+        self.map(handle, |j| utils::flat_handle(j.body1.0))
     }
 
     /// The unique integer identifier of the second rigid-body this joint is attached to.
     pub fn jointBodyHandle2(&self, handle: FlatHandle) -> FlatHandle {
-        self.map(handle, |j| utils::fuse_handle(j.body2.0))
+        self.map(handle, |j| utils::flat_handle(j.body2.0))
     }
 
     /// The angular part of the joint’s local frame relative to the first rigid-body it is attached to.

--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -1,3 +1,4 @@
+use crate::utils;
 use rapier::dynamics::IslandManager;
 use wasm_bindgen::prelude::*;
 
@@ -24,7 +25,7 @@ impl RawIslandManager {
     pub fn forEachActiveRigidBodyHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for handle in self.0.active_dynamic_bodies() {
-            let _ = f.call1(&this, &JsValue::from(handle.into_raw_parts().0 as u32));
+            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
         }
     }
 }

--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -25,7 +25,7 @@ impl RawIslandManager {
     pub fn forEachActiveRigidBodyHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for handle in self.0.active_dynamic_bodies() {
-            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
+            let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
         }
     }
 }

--- a/src/dynamics/multibody_joint.rs
+++ b/src/dynamics/multibody_joint.rs
@@ -1,32 +1,33 @@
 use crate::dynamics::{RawJointAxis, RawJointType, RawMultibodyJointSet};
 use crate::math::{RawRotation, RawVector};
+use crate::utils::FlatHandle;
 use rapier::dynamics::JointAxis;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 impl RawMultibodyJointSet {
     /// The type of this joint.
-    pub fn jointType(&self, handle: u32) -> RawJointType {
+    pub fn jointType(&self, handle: FlatHandle) -> RawJointType {
         self.map(handle, |j| j.data.locked_axes.into())
     }
 
     // /// The unique integer identifier of the first rigid-body this joint it attached to.
-    // pub fn jointBodyHandle1(&self, handle: u32) -> u32 {
+    // pub fn jointBodyHandle1(&self, handle: FlatHandle) -> u32 {
     //     self.map(handle, |j| j.body1.into_raw_parts().0)
     // }
     //
     // /// The unique integer identifier of the second rigid-body this joint is attached to.
-    // pub fn jointBodyHandle2(&self, handle: u32) -> u32 {
+    // pub fn jointBodyHandle2(&self, handle: FlatHandle) -> u32 {
     //     self.map(handle, |j| j.body2.into_raw_parts().0)
     // }
 
     /// The angular part of the joint’s local frame relative to the first rigid-body it is attached to.
-    pub fn jointFrameX1(&self, handle: u32) -> RawRotation {
+    pub fn jointFrameX1(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |j| j.data.local_frame1.rotation.into())
     }
 
     /// The angular part of the joint’s local frame relative to the second rigid-body it is attached to.
-    pub fn jointFrameX2(&self, handle: u32) -> RawRotation {
+    pub fn jointFrameX2(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |j| j.data.local_frame2.rotation.into())
     }
 
@@ -34,7 +35,7 @@ impl RawMultibodyJointSet {
     ///
     /// The first anchor gives the position of the points application point on the
     /// local frame of the first rigid-body it is attached to.
-    pub fn jointAnchor1(&self, handle: u32) -> RawVector {
+    pub fn jointAnchor1(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |j| j.data.local_frame1.translation.vector.into())
     }
 
@@ -42,30 +43,30 @@ impl RawMultibodyJointSet {
     ///
     /// The second anchor gives the position of the points application point on the
     /// local frame of the second rigid-body it is attached to.
-    pub fn jointAnchor2(&self, handle: u32) -> RawVector {
+    pub fn jointAnchor2(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |j| j.data.local_frame2.translation.vector.into())
     }
 
     /// Are the limits for this joint enabled?
-    pub fn jointLimitsEnabled(&self, handle: u32, axis: RawJointAxis) -> bool {
+    pub fn jointLimitsEnabled(&self, handle: FlatHandle, axis: RawJointAxis) -> bool {
         self.map(handle, |j| {
             j.data.limit_axes.contains(JointAxis::from(axis).into())
         })
     }
 
     /// Return the lower limit along the given joint axis.
-    pub fn jointLimitsMin(&self, handle: u32, axis: RawJointAxis) -> f32 {
+    pub fn jointLimitsMin(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].min)
     }
 
     /// If this is a prismatic joint, returns its upper limit.
-    pub fn jointLimitsMax(&self, handle: u32, axis: RawJointAxis) -> f32 {
+    pub fn jointLimitsMax(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].max)
     }
 
     // pub fn jointConfigureMotorModel(
     //     &mut self,
-    //     handle: u32,
+    //     handle: FlatHandle,
     //     axis: RawJointAxis,
     //     model: RawMotorModel,
     // ) {
@@ -78,7 +79,7 @@ impl RawMultibodyJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotorVelocity(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         vx: f32,
         vy: f32,
         vz: f32,
@@ -95,7 +96,7 @@ impl RawMultibodyJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotorPosition(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         qw: f32,
         qx: f32,
         qy: f32,
@@ -118,7 +119,7 @@ impl RawMultibodyJointSet {
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotor(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         qw: f32,
         qx: f32,
         qy: f32,
@@ -145,7 +146,7 @@ impl RawMultibodyJointSet {
 
     // pub fn jointConfigureMotorVelocity(
     //     &mut self,
-    //     handle: u32,
+    //     handle: FlatHandle,
     //     axis: RawJointAxis,
     //     targetVel: f32,
     //     factor: f32,
@@ -155,7 +156,7 @@ impl RawMultibodyJointSet {
     //
     // pub fn jointConfigureMotorPosition(
     //     &mut self,
-    //     handle: u32,
+    //     handle: FlatHandle,
     //     axis: RawJointAxis,
     //     targetPos: f32,
     //     stiffness: f32,
@@ -166,7 +167,7 @@ impl RawMultibodyJointSet {
 
     // pub fn jointConfigureMotor(
     //     &mut self,
-    //     handle: u32,
+    //     handle: FlatHandle,
     //     axis: RawJointAxis,
     //     targetPos: f32,
     //     targetVel: f32,

--- a/src/dynamics/multibody_joint_set.rs
+++ b/src/dynamics/multibody_joint_set.rs
@@ -1,4 +1,4 @@
-use crate::dynamics::{RawGenericJoint, RawIslandManager, RawRigidBodySet};
+use crate::dynamics::RawGenericJoint;
 use crate::utils::{self, FlatHandle};
 use rapier::dynamics::{MultibodyJoint, MultibodyJointSet};
 use wasm_bindgen::prelude::*;
@@ -40,26 +40,21 @@ impl RawMultibodyJointSet {
         params: &RawGenericJoint,
         parent1: FlatHandle,
         parent2: FlatHandle,
+        wakeUp: bool,
     ) -> FlatHandle {
         // TODO: avoid the unwrap?
         let parent1 = utils::body_handle(parent1);
         let parent2 = utils::body_handle(parent2);
 
         self.0
-            .insert(parent1, parent2, params.0.clone())
-            .map(|h| utils::fuse_handle(h.0))
+            .insert(parent1, parent2, params.0.clone(), wakeUp)
+            .map(|h| utils::flat_handle(h.0))
             .unwrap_or(FlatHandle::MAX)
     }
 
-    pub fn remove(
-        &mut self,
-        handle: FlatHandle,
-        islands: &mut RawIslandManager,
-        bodies: &mut RawRigidBodySet,
-        wakeUp: bool,
-    ) {
+    pub fn remove(&mut self, handle: FlatHandle, wakeUp: bool) {
         let handle = utils::multibody_joint_handle(handle);
-        self.0.remove(handle, &mut islands.0, &mut bodies.0, wakeUp);
+        self.0.remove(handle, wakeUp);
     }
 
     pub fn contains(&self, handle: FlatHandle) -> bool {
@@ -73,7 +68,18 @@ impl RawMultibodyJointSet {
     pub fn forEachJointHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
+            let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
+        }
+    }
+
+    /// Applies the given JavaScript function to the integer handle of each joint attached to the given rigid-body.
+    ///
+    /// # Parameters
+    /// - `f(handle)`: the function to apply to the integer handle of each joint attached to the rigid-body. Called as `f(collider)`.
+    pub fn forEachJointAttachedToRigidBody(&self, body: FlatHandle, f: &js_sys::Function) {
+        let this = JsValue::null();
+        for (_, _, handle) in self.0.attached_joints(utils::body_handle(body)) {
+            let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
         }
     }
 }

--- a/src/dynamics/multibody_joint_set.rs
+++ b/src/dynamics/multibody_joint_set.rs
@@ -1,4 +1,5 @@
 use crate::dynamics::{RawGenericJoint, RawIslandManager, RawRigidBodySet};
+use crate::utils::{self, FlatHandle};
 use rapier::dynamics::{MultibodyJoint, MultibodyJointSet};
 use wasm_bindgen::prelude::*;
 
@@ -6,22 +7,22 @@ use wasm_bindgen::prelude::*;
 pub struct RawMultibodyJointSet(pub(crate) MultibodyJointSet);
 
 impl RawMultibodyJointSet {
-    pub(crate) fn map<T>(&self, handle: u32, f: impl FnOnce(&MultibodyJoint) -> T) -> T {
-        let (body, link_id, _) = self
+    pub(crate) fn map<T>(&self, handle: FlatHandle, f: impl FnOnce(&MultibodyJoint) -> T) -> T {
+        let (body, link_id) = self
             .0
-            .get_unknown_gen(handle)
+            .get(utils::multibody_joint_handle(handle))
             .expect("Invalid Joint reference. It may have been removed from the physics World.");
         f(body.link(link_id).unwrap().joint())
     }
 
     // pub(crate) fn map_mut<T>(
     //     &mut self,
-    //     handle: u32,
+    //     handle: FlatHandle,
     //     f: impl FnOnce(&mut MultibodyJoint) -> T,
     // ) -> T {
     //     let (body, link_id, _) = self
     //         .0
-    //         .get_unknown_gen_mut(handle)
+    //         .get_mut(utils::multibody_handle(handle))
     //         .expect("Invalid Joint reference. It may have been removed from the physics World.");
     //     f(body.link(link_id).unwrap().joint())
     // }
@@ -36,35 +37,33 @@ impl RawMultibodyJointSet {
 
     pub fn createJoint(
         &mut self,
-        bodies: &mut RawRigidBodySet,
         params: &RawGenericJoint,
-        parent1: u32,
-        parent2: u32,
-    ) -> u32 {
+        parent1: FlatHandle,
+        parent2: FlatHandle,
+    ) -> FlatHandle {
         // TODO: avoid the unwrap?
-        let parent1 = bodies.0.get_unknown_gen(parent1).unwrap().1;
-        let parent2 = bodies.0.get_unknown_gen(parent2).unwrap().1;
+        let parent1 = utils::body_handle(parent1);
+        let parent2 = utils::body_handle(parent2);
 
         self.0
             .insert(parent1, parent2, params.0.clone())
-            .map(|h| h.into_raw_parts().0)
-            .unwrap_or(u32::MAX)
+            .map(|h| utils::fuse_handle(h.0))
+            .unwrap_or(FlatHandle::MAX)
     }
 
     pub fn remove(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         islands: &mut RawIslandManager,
         bodies: &mut RawRigidBodySet,
         wakeUp: bool,
     ) {
-        if let Some((_, _, handle)) = self.0.get_unknown_gen(handle) {
-            self.0.remove(handle, &mut islands.0, &mut bodies.0, wakeUp);
-        }
+        let handle = utils::multibody_joint_handle(handle);
+        self.0.remove(handle, &mut islands.0, &mut bodies.0, wakeUp);
     }
 
-    pub fn contains(&self, handle: u32) -> bool {
-        self.0.get_unknown_gen(handle).is_some()
+    pub fn contains(&self, handle: FlatHandle) -> bool {
+        self.0.get(utils::multibody_joint_handle(handle)).is_some()
     }
 
     /// Applies the given JavaScript function to the integer handle of each joint managed by this physics world.
@@ -74,7 +73,7 @@ impl RawMultibodyJointSet {
     pub fn forEachJointHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(handle.into_raw_parts().0 as u32));
+            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
         }
     }
 }

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1,31 +1,32 @@
 use crate::dynamics::{RawRigidBodySet, RawRigidBodyType};
 use crate::math::{RawRotation, RawVector};
+use crate::utils::{self, FlatHandle};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 impl RawRigidBodySet {
     /// The world-space translation of this rigid-body.
-    pub fn rbTranslation(&self, handle: u32) -> RawVector {
+    pub fn rbTranslation(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |rb| RawVector(rb.position().translation.vector))
     }
 
     /// The world-space orientation of this rigid-body.
-    pub fn rbRotation(&self, handle: u32) -> RawRotation {
+    pub fn rbRotation(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |rb| RawRotation(rb.position().rotation))
     }
 
     /// Put the given rigid-body to sleep.
-    pub fn rbSleep(&mut self, handle: u32) {
+    pub fn rbSleep(&mut self, handle: FlatHandle) {
         self.map_mut(handle, |rb| rb.sleep());
     }
 
     /// Is this rigid-body sleeping?
-    pub fn rbIsSleeping(&self, handle: u32) -> bool {
+    pub fn rbIsSleeping(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_sleeping())
     }
 
     /// Is the velocity of this rigid-body not zero?
-    pub fn rbIsMoving(&self, handle: u32) -> bool {
+    pub fn rbIsMoving(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_moving())
     }
 
@@ -34,7 +35,7 @@ impl RawRigidBodySet {
     /// If this rigid-body is kinematic this value is set by the `setNextKinematicTranslation`
     /// method and is used for estimating the kinematic body velocity at the next timestep.
     /// For non-kinematic bodies, this value is currently unspecified.
-    pub fn rbNextTranslation(&self, handle: u32) -> RawVector {
+    pub fn rbNextTranslation(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |rb| {
             RawVector(rb.next_position().translation.vector)
         })
@@ -45,7 +46,7 @@ impl RawRigidBodySet {
     /// If this rigid-body is kinematic this value is set by the `setNextKinematicRotation`
     /// method and is used for estimating the kinematic body velocity at the next timestep.
     /// For non-kinematic bodies, this value is currently unspecified.
-    pub fn rbNextRotation(&self, handle: u32) -> RawRotation {
+    pub fn rbNextRotation(&self, handle: FlatHandle) -> RawRotation {
         self.map(handle, |rb| RawRotation(rb.next_position().rotation))
     }
 
@@ -58,7 +59,7 @@ impl RawRigidBodySet {
     /// - `wakeUp`: forces the rigid-body to wake-up so it is properly affected by forces if it
     /// wasn't moving before modifying its position.
     #[cfg(feature = "dim3")]
-    pub fn rbSetTranslation(&mut self, handle: u32, x: f32, y: f32, z: f32, wakeUp: bool) {
+    pub fn rbSetTranslation(&mut self, handle: FlatHandle, x: f32, y: f32, z: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.set_translation(na::Vector3::new(x, y, z), wakeUp);
         })
@@ -72,7 +73,7 @@ impl RawRigidBodySet {
     /// - `wakeUp`: forces the rigid-body to wake-up so it is properly affected by forces if it
     /// wasn't moving before modifying its position.
     #[cfg(feature = "dim2")]
-    pub fn rbSetTranslation(&mut self, handle: u32, x: f32, y: f32, wakeUp: bool) {
+    pub fn rbSetTranslation(&mut self, handle: FlatHandle, x: f32, y: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.set_translation(na::Vector2::new(x, y), wakeUp);
         })
@@ -90,7 +91,15 @@ impl RawRigidBodySet {
     /// - `wakeUp`: forces the rigid-body to wake-up so it is properly affected by forces if it
     /// wasn't moving before modifying its position.
     #[cfg(feature = "dim3")]
-    pub fn rbSetRotation(&mut self, handle: u32, x: f32, y: f32, z: f32, w: f32, wakeUp: bool) {
+    pub fn rbSetRotation(
+        &mut self,
+        handle: FlatHandle,
+        x: f32,
+        y: f32,
+        z: f32,
+        w: f32,
+        wakeUp: bool,
+    ) {
         if let Some(q) = na::Unit::try_new(na::Quaternion::new(w, x, y, z), 0.0) {
             self.map_mut(handle, |rb| rb.set_rotation(q.scaled_axis(), wakeUp))
         }
@@ -103,12 +112,12 @@ impl RawRigidBodySet {
     /// - `wakeUp`: forces the rigid-body to wake-up so it is properly affected by forces if it
     /// wasn't moving before modifying its position.
     #[cfg(feature = "dim2")]
-    pub fn rbSetRotation(&mut self, handle: u32, angle: f32, wakeUp: bool) {
+    pub fn rbSetRotation(&mut self, handle: FlatHandle, angle: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| rb.set_rotation(angle, wakeUp))
     }
 
     /// Sets the linear velocity of this rigid-body.
-    pub fn rbSetLinvel(&mut self, handle: u32, linvel: &RawVector, wakeUp: bool) {
+    pub fn rbSetLinvel(&mut self, handle: FlatHandle, linvel: &RawVector, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.set_linvel(linvel.0, wakeUp);
         });
@@ -116,7 +125,7 @@ impl RawRigidBodySet {
 
     /// Sets the angular velocity of this rigid-body.
     #[cfg(feature = "dim2")]
-    pub fn rbSetAngvel(&mut self, handle: u32, angvel: f32, wakeUp: bool) {
+    pub fn rbSetAngvel(&mut self, handle: FlatHandle, angvel: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.set_angvel(angvel, wakeUp);
         });
@@ -124,7 +133,7 @@ impl RawRigidBodySet {
 
     /// Sets the angular velocity of this rigid-body.
     #[cfg(feature = "dim3")]
-    pub fn rbSetAngvel(&mut self, handle: u32, angvel: &RawVector, wakeUp: bool) {
+    pub fn rbSetAngvel(&mut self, handle: FlatHandle, angvel: &RawVector, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.set_angvel(angvel.0, wakeUp);
         });
@@ -143,7 +152,7 @@ impl RawRigidBodySet {
     /// - `y`: the world-space position of the rigid-body along the `y` axis.
     /// - `z`: the world-space position of the rigid-body along the `z` axis.
     #[cfg(feature = "dim3")]
-    pub fn rbSetNextKinematicTranslation(&mut self, handle: u32, x: f32, y: f32, z: f32) {
+    pub fn rbSetNextKinematicTranslation(&mut self, handle: FlatHandle, x: f32, y: f32, z: f32) {
         self.map_mut(handle, |rb| {
             rb.set_next_kinematic_translation(na::Vector3::new(x, y, z));
         })
@@ -161,7 +170,7 @@ impl RawRigidBodySet {
     /// - `x`: the world-space position of the rigid-body along the `x` axis.
     /// - `y`: the world-space position of the rigid-body along the `y` axis.
     #[cfg(feature = "dim2")]
-    pub fn rbSetNextKinematicTranslation(&mut self, handle: u32, x: f32, y: f32) {
+    pub fn rbSetNextKinematicTranslation(&mut self, handle: FlatHandle, x: f32, y: f32) {
         self.map_mut(handle, |rb| {
             rb.set_next_kinematic_translation(na::Vector2::new(x, y));
         })
@@ -181,7 +190,14 @@ impl RawRigidBodySet {
     /// - `z`: the third vector component of the quaternion.
     /// - `w`: the scalar component of the quaternion.
     #[cfg(feature = "dim3")]
-    pub fn rbSetNextKinematicRotation(&mut self, handle: u32, x: f32, y: f32, z: f32, w: f32) {
+    pub fn rbSetNextKinematicRotation(
+        &mut self,
+        handle: FlatHandle,
+        x: f32,
+        y: f32,
+        z: f32,
+        w: f32,
+    ) {
         if let Some(q) = na::Unit::try_new(na::Quaternion::new(w, x, y, z), 0.0) {
             self.map_mut(handle, |rb| {
                 rb.set_next_kinematic_rotation(q.scaled_axis());
@@ -200,37 +216,37 @@ impl RawRigidBodySet {
     /// # Parameters
     /// - `angle`: the rotation angle, in radians.
     #[cfg(feature = "dim2")]
-    pub fn rbSetNextKinematicRotation(&mut self, handle: u32, angle: f32) {
+    pub fn rbSetNextKinematicRotation(&mut self, handle: FlatHandle, angle: f32) {
         self.map_mut(handle, |rb| {
             rb.set_next_kinematic_rotation(angle);
         })
     }
 
     /// The linear velocity of this rigid-body.
-    pub fn rbLinvel(&self, handle: u32) -> RawVector {
+    pub fn rbLinvel(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |rb| RawVector(*rb.linvel()))
     }
 
     /// The angular velocity of this rigid-body.
     #[cfg(feature = "dim2")]
-    pub fn rbAngvel(&self, handle: u32) -> f32 {
+    pub fn rbAngvel(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.angvel())
     }
 
     /// The angular velocity of this rigid-body.
     #[cfg(feature = "dim3")]
-    pub fn rbAngvel(&self, handle: u32) -> RawVector {
+    pub fn rbAngvel(&self, handle: FlatHandle) -> RawVector {
         self.map(handle, |rb| RawVector(*rb.angvel()))
     }
 
-    pub fn rbLockTranslations(&mut self, handle: u32, locked: bool, wake_up: bool) {
+    pub fn rbLockTranslations(&mut self, handle: FlatHandle, locked: bool, wake_up: bool) {
         self.map_mut(handle, |rb| rb.lock_translations(locked, wake_up))
     }
 
     #[cfg(feature = "dim2")]
     pub fn rbRestrictTranslations(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         allow_x: bool,
         allow_y: bool,
         wake_up: bool,
@@ -243,7 +259,7 @@ impl RawRigidBodySet {
     #[cfg(feature = "dim3")]
     pub fn rbRestrictTranslations(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         allow_x: bool,
         allow_y: bool,
         allow_z: bool,
@@ -254,14 +270,14 @@ impl RawRigidBodySet {
         })
     }
 
-    pub fn rbLockRotations(&mut self, handle: u32, locked: bool, wake_up: bool) {
+    pub fn rbLockRotations(&mut self, handle: FlatHandle, locked: bool, wake_up: bool) {
         self.map_mut(handle, |rb| rb.lock_rotations(locked, wake_up))
     }
 
     #[cfg(feature = "dim3")]
     pub fn rbRestrictRotations(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         allow_x: bool,
         allow_y: bool,
         allow_z: bool,
@@ -272,20 +288,20 @@ impl RawRigidBodySet {
         })
     }
 
-    pub fn rbDominanceGroup(&self, handle: u32) -> i8 {
+    pub fn rbDominanceGroup(&self, handle: FlatHandle) -> i8 {
         self.map(handle, |rb| rb.dominance_group())
     }
 
-    pub fn rbSetDominanceGroup(&mut self, handle: u32, group: i8) {
+    pub fn rbSetDominanceGroup(&mut self, handle: FlatHandle, group: i8) {
         self.map_mut(handle, |rb| rb.set_dominance_group(group))
     }
 
-    pub fn rbEnableCcd(&mut self, handle: u32, enabled: bool) {
+    pub fn rbEnableCcd(&mut self, handle: FlatHandle, enabled: bool) {
         self.map_mut(handle, |rb| rb.enable_ccd(enabled))
     }
 
     /// The mass of this rigid-body.
-    pub fn rbMass(&self, handle: u32) -> f32 {
+    pub fn rbMass(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.mass())
     }
 
@@ -296,17 +312,17 @@ impl RawRigidBodySet {
     /// to avoid useless computations.
     /// This methods forces a sleeping rigid-body to wake-up. This is useful, e.g., before modifying
     /// the position of a dynamic body so that it is properly simulated afterwards.
-    pub fn rbWakeUp(&mut self, handle: u32) {
+    pub fn rbWakeUp(&mut self, handle: FlatHandle) {
         self.map_mut(handle, |rb| rb.wake_up(true))
     }
 
     /// Is Continuous Collision Detection enabled for this rigid-body?
-    pub fn rbIsCcdEnabled(&self, handle: u32) -> bool {
+    pub fn rbIsCcdEnabled(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_ccd_enabled())
     }
 
     /// The number of colliders attached to this rigid-body.
-    pub fn rbNumColliders(&self, handle: u32) -> usize {
+    pub fn rbNumColliders(&self, handle: FlatHandle) -> usize {
         self.map(handle, |rb| rb.colliders().len())
     }
 
@@ -315,70 +331,70 @@ impl RawRigidBodySet {
     /// # Parameters
     /// - `at`: The index of the collider to retrieve. Must be a number in `[0, this.numColliders()[`.
     ///         This index is **not** the same as the unique identifier of the collider.
-    pub fn rbCollider(&self, handle: u32, at: usize) -> u32 {
-        self.map(handle, |rb| rb.colliders()[at].into_raw_parts().0)
+    pub fn rbCollider(&self, handle: FlatHandle, at: usize) -> FlatHandle {
+        self.map(handle, |rb| utils::fuse_handle(rb.colliders()[at].0))
     }
 
     /// The status of this rigid-body: fixed, dynamic, or kinematic.
-    pub fn rbBodyType(&self, handle: u32) -> RawRigidBodyType {
+    pub fn rbBodyType(&self, handle: FlatHandle) -> RawRigidBodyType {
         self.map(handle, |rb| rb.body_type().into())
     }
 
     /// Set a new status for this rigid-body: fixed, dynamic, or kinematic.
-    pub fn rbSetBodyType(&mut self, handle: u32, status: RawRigidBodyType) {
+    pub fn rbSetBodyType(&mut self, handle: FlatHandle, status: RawRigidBodyType) {
         self.map_mut(handle, |rb| rb.set_body_type(status.into()));
     }
 
     /// Is this rigid-body fixed?
-    pub fn rbIsFixed(&self, handle: u32) -> bool {
+    pub fn rbIsFixed(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_fixed())
     }
 
     /// Is this rigid-body kinematic?
-    pub fn rbIsKinematic(&self, handle: u32) -> bool {
+    pub fn rbIsKinematic(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_kinematic())
     }
 
     /// Is this rigid-body dynamic?
-    pub fn rbIsDynamic(&self, handle: u32) -> bool {
+    pub fn rbIsDynamic(&self, handle: FlatHandle) -> bool {
         self.map(handle, |rb| rb.is_dynamic())
     }
 
     /// The linear damping coefficient of this rigid-body.
-    pub fn rbLinearDamping(&self, handle: u32) -> f32 {
+    pub fn rbLinearDamping(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.linear_damping())
     }
 
     /// The angular damping coefficient of this rigid-body.
-    pub fn rbAngularDamping(&self, handle: u32) -> f32 {
+    pub fn rbAngularDamping(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.angular_damping())
     }
 
-    pub fn rbSetLinearDamping(&mut self, handle: u32, factor: f32) {
+    pub fn rbSetLinearDamping(&mut self, handle: FlatHandle, factor: f32) {
         self.map_mut(handle, |rb| rb.set_linear_damping(factor));
     }
 
-    pub fn rbSetAngularDamping(&mut self, handle: u32, factor: f32) {
+    pub fn rbSetAngularDamping(&mut self, handle: FlatHandle, factor: f32) {
         self.map_mut(handle, |rb| rb.set_angular_damping(factor));
     }
 
-    pub fn rbGravityScale(&self, handle: u32) -> f32 {
+    pub fn rbGravityScale(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.gravity_scale())
     }
 
-    pub fn rbSetGravityScale(&mut self, handle: u32, factor: f32, wakeUp: bool) {
+    pub fn rbSetGravityScale(&mut self, handle: FlatHandle, factor: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| rb.set_gravity_scale(factor, wakeUp));
     }
 
     /// Resets to zero all user-added forces added to this rigid-body.
-    pub fn rbResetForces(&mut self, handle: u32, wakeUp: bool) {
+    pub fn rbResetForces(&mut self, handle: FlatHandle, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.reset_forces(wakeUp);
         })
     }
 
     /// Resets to zero all user-added torques added to this rigid-body.
-    pub fn rbResetTorques(&mut self, handle: u32, wakeUp: bool) {
+    pub fn rbResetTorques(&mut self, handle: FlatHandle, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.reset_torques(wakeUp);
         })
@@ -389,7 +405,7 @@ impl RawRigidBodySet {
     /// # Parameters
     /// - `force`: the world-space force to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
-    pub fn rbAddForce(&mut self, handle: u32, force: &RawVector, wakeUp: bool) {
+    pub fn rbAddForce(&mut self, handle: FlatHandle, force: &RawVector, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.add_force(force.0, wakeUp);
         })
@@ -400,7 +416,7 @@ impl RawRigidBodySet {
     /// # Parameters
     /// - `impulse`: the world-space impulse to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
-    pub fn rbApplyImpulse(&mut self, handle: u32, impulse: &RawVector, wakeUp: bool) {
+    pub fn rbApplyImpulse(&mut self, handle: FlatHandle, impulse: &RawVector, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.apply_impulse(impulse.0, wakeUp);
         })
@@ -412,7 +428,7 @@ impl RawRigidBodySet {
     /// - `torque`: the torque to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     #[cfg(feature = "dim2")]
-    pub fn rbAddTorque(&mut self, handle: u32, torque: f32, wakeUp: bool) {
+    pub fn rbAddTorque(&mut self, handle: FlatHandle, torque: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.add_torque(torque, wakeUp);
         })
@@ -424,7 +440,7 @@ impl RawRigidBodySet {
     /// - `torque`: the world-space torque to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     #[cfg(feature = "dim3")]
-    pub fn rbAddTorque(&mut self, handle: u32, torque: &RawVector, wakeUp: bool) {
+    pub fn rbAddTorque(&mut self, handle: FlatHandle, torque: &RawVector, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.add_torque(torque.0, wakeUp);
         })
@@ -436,7 +452,7 @@ impl RawRigidBodySet {
     /// - `torque impulse`: the torque impulse to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     #[cfg(feature = "dim2")]
-    pub fn rbApplyTorqueImpulse(&mut self, handle: u32, torque_impulse: f32, wakeUp: bool) {
+    pub fn rbApplyTorqueImpulse(&mut self, handle: FlatHandle, torque_impulse: f32, wakeUp: bool) {
         self.map_mut(handle, |rb| {
             rb.apply_torque_impulse(torque_impulse, wakeUp);
         })
@@ -448,7 +464,12 @@ impl RawRigidBodySet {
     /// - `torque impulse`: the world-space torque impulse to apply on the rigid-body.
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     #[cfg(feature = "dim3")]
-    pub fn rbApplyTorqueImpulse(&mut self, handle: u32, torque_impulse: &RawVector, wakeUp: bool) {
+    pub fn rbApplyTorqueImpulse(
+        &mut self,
+        handle: FlatHandle,
+        torque_impulse: &RawVector,
+        wakeUp: bool,
+    ) {
         self.map_mut(handle, |rb| {
             rb.apply_torque_impulse(torque_impulse.0, wakeUp);
         })
@@ -462,7 +483,7 @@ impl RawRigidBodySet {
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     pub fn rbAddForceAtPoint(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         force: &RawVector,
         point: &RawVector,
         wakeUp: bool,
@@ -480,7 +501,7 @@ impl RawRigidBodySet {
     /// - `wakeUp`: should the rigid-body be automatically woken-up?
     pub fn rbApplyImpulseAtPoint(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         impulse: &RawVector,
         point: &RawVector,
         wakeUp: bool,
@@ -491,7 +512,7 @@ impl RawRigidBodySet {
     }
 
     /// An arbitrary user-defined 32-bit integer
-    pub fn rbUserData(&self, handle: u32) -> u32 {
+    pub fn rbUserData(&self, handle: FlatHandle) -> u32 {
         self.map(handle, |rb| rb.user_data as u32)
     }
 
@@ -499,7 +520,7 @@ impl RawRigidBodySet {
     ///
     /// # Parameters
     /// - `data`: an arbitrary user-defined 32-bit integer.
-    pub fn rbSetUserData(&mut self, handle: u32, data: u32) {
+    pub fn rbSetUserData(&mut self, handle: FlatHandle, data: u32) {
         self.map_mut(handle, |rb| {
             rb.user_data = data as u128;
         })

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -332,7 +332,7 @@ impl RawRigidBodySet {
     /// - `at`: The index of the collider to retrieve. Must be a number in `[0, this.numColliders()[`.
     ///         This index is **not** the same as the unique identifier of the collider.
     pub fn rbCollider(&self, handle: FlatHandle, at: usize) -> FlatHandle {
-        self.map(handle, |rb| utils::fuse_handle(rb.colliders()[at].0))
+        self.map(handle, |rb| utils::flat_handle(rb.colliders()[at].0))
     }
 
     /// The status of this rigid-body: fixed, dynamic, or kinematic.

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -1,6 +1,7 @@
 use crate::dynamics::{RawImpulseJointSet, RawIslandManager, RawMultibodyJointSet};
 use crate::geometry::RawColliderSet;
 use crate::math::{RawRotation, RawVector};
+use crate::utils::{self, FlatHandle};
 use rapier::dynamics::{MassProperties, RigidBody, RigidBodyBuilder, RigidBodySet, RigidBodyType};
 use wasm_bindgen::prelude::*;
 
@@ -38,15 +39,19 @@ impl Into<RawRigidBodyType> for RigidBodyType {
 pub struct RawRigidBodySet(pub(crate) RigidBodySet);
 
 impl RawRigidBodySet {
-    pub(crate) fn map<T>(&self, handle: u32, f: impl FnOnce(&RigidBody) -> T) -> T {
-        let (body, _) = self.0.get_unknown_gen(handle).expect(
+    pub(crate) fn map<T>(&self, handle: FlatHandle, f: impl FnOnce(&RigidBody) -> T) -> T {
+        let body = self.0.get(utils::body_handle(handle)).expect(
             "Invalid RigidBody reference. It may have been removed from the physics World.",
         );
         f(body)
     }
 
-    pub(crate) fn map_mut<T>(&mut self, handle: u32, f: impl FnOnce(&mut RigidBody) -> T) -> T {
-        let (body, _) = self.0.get_unknown_gen_mut(handle).expect(
+    pub(crate) fn map_mut<T>(
+        &mut self,
+        handle: FlatHandle,
+        f: impl FnOnce(&mut RigidBody) -> T,
+    ) -> T {
+        let body = self.0.get_mut(utils::body_handle(handle)).expect(
             "Invalid RigidBody reference. It may have been removed from the physics World.",
         );
         f(body)
@@ -85,7 +90,7 @@ impl RawRigidBodySet {
         sleeping: bool,
         ccdEnabled: bool,
         dominanceGroup: i8,
-    ) -> u32 {
+    ) -> FlatHandle {
         let pos = na::Isometry3::from_parts(translation.0.into(), rotation.0);
         let props = MassProperties::with_principal_inertia_frame(
             centerOfMass.0.into(),
@@ -115,7 +120,7 @@ impl RawRigidBodySet {
             .ccd_enabled(ccdEnabled)
             .dominance_group(dominanceGroup);
 
-        self.0.insert(rigid_body.build()).into_raw_parts().0
+        utils::fuse_handle(self.0.insert(rigid_body.build()).0)
     }
 
     #[cfg(feature = "dim2")]
@@ -139,7 +144,7 @@ impl RawRigidBodySet {
         sleeping: bool,
         ccdEnabled: bool,
         dominanceGroup: i8,
-    ) -> u32 {
+    ) -> FlatHandle {
         let pos = na::Isometry2::from_parts(translation.0.into(), rotation.0);
         let props = MassProperties::new(centerOfMass.0.into(), mass, principalAngularInertia);
         let mut rigid_body = RigidBodyBuilder::new(rb_type.into())
@@ -162,27 +167,26 @@ impl RawRigidBodySet {
             rigid_body = rigid_body.lock_rotations();
         }
 
-        self.0.insert(rigid_body.build()).into_raw_parts().0
+        utils::fuse_handle(self.0.insert(rigid_body.build()).0)
     }
 
     pub fn remove(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         islands: &mut RawIslandManager,
         colliders: &mut RawColliderSet,
         joints: &mut RawImpulseJointSet,
         articulations: &mut RawMultibodyJointSet,
     ) {
-        if let Some((_, handle)) = self.0.get_unknown_gen(handle) {
-            self.0.remove(
-                handle,
-                &mut islands.0,
-                &mut colliders.0,
-                &mut joints.0,
-                &mut articulations.0,
-                true,
-            );
-        }
+        let handle = utils::body_handle(handle);
+        self.0.remove(
+            handle,
+            &mut islands.0,
+            &mut colliders.0,
+            &mut joints.0,
+            &mut articulations.0,
+            true,
+        );
     }
 
     /// The number of rigid-bodies on this set.
@@ -191,8 +195,8 @@ impl RawRigidBodySet {
     }
 
     /// Checks if a rigid-body with the given integer handle exists.
-    pub fn contains(&self, handle: u32) -> bool {
-        self.0.get_unknown_gen(handle).is_some()
+    pub fn contains(&self, handle: FlatHandle) -> bool {
+        self.0.get(utils::body_handle(handle)).is_some()
     }
 
     /// Applies the given JavaScript function to the integer handle of each rigid-body managed by this set.
@@ -202,7 +206,7 @@ impl RawRigidBodySet {
     pub fn forEachRigidBodyHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(handle.into_raw_parts().0 as u32));
+            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
         }
     }
 }

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -120,7 +120,7 @@ impl RawRigidBodySet {
             .ccd_enabled(ccdEnabled)
             .dominance_group(dominanceGroup);
 
-        utils::fuse_handle(self.0.insert(rigid_body.build()).0)
+        utils::flat_handle(self.0.insert(rigid_body.build()).0)
     }
 
     #[cfg(feature = "dim2")]
@@ -167,7 +167,7 @@ impl RawRigidBodySet {
             rigid_body = rigid_body.lock_rotations();
         }
 
-        utils::fuse_handle(self.0.insert(rigid_body.build()).0)
+        utils::flat_handle(self.0.insert(rigid_body.build()).0)
     }
 
     pub fn remove(
@@ -206,7 +206,7 @@ impl RawRigidBodySet {
     pub fn forEachRigidBodyHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
+            let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
         }
     }
 }

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -327,7 +327,7 @@ impl RawColliderSet {
 
     /// The unique integer identifier of the collider this collider is attached to.
     pub fn coParent(&self, handle: FlatHandle) -> Option<FlatHandle> {
-        self.map(handle, |co| co.parent().map(|p| utils::fuse_handle(p.0)))
+        self.map(handle, |co| co.parent().map(|p| utils::flat_handle(p.0)))
     }
 
     /// The friction coefficient of this collider.

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -94,13 +94,13 @@ impl RawColliderSet {
         let collider = builder.build();
 
         if hasParent {
-            Some(utils::fuse_handle(
+            Some(utils::flat_handle(
                 self.0
                     .insert_with_parent(collider, utils::body_handle(parent), &mut bodies.0)
                     .0,
             ))
         } else {
-            Some(utils::fuse_handle(self.0.insert(collider).0))
+            Some(utils::flat_handle(self.0.insert(collider).0))
         }
     }
 }
@@ -246,7 +246,7 @@ impl RawColliderSet {
     pub fn forEachColliderHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
+            let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
         }
     }
 }

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -1,6 +1,7 @@
 use crate::dynamics::{RawIslandManager, RawRigidBodySet};
 use crate::geometry::RawShape;
 use crate::math::{RawRotation, RawVector};
+use crate::utils::{self, FlatHandle};
 use rapier::prelude::*;
 use wasm_bindgen::prelude::*;
 
@@ -8,18 +9,22 @@ use wasm_bindgen::prelude::*;
 pub struct RawColliderSet(pub(crate) ColliderSet);
 
 impl RawColliderSet {
-    pub(crate) fn map<T>(&self, handle: u32, f: impl FnOnce(&Collider) -> T) -> T {
-        let (collider, _) = self
+    pub(crate) fn map<T>(&self, handle: FlatHandle, f: impl FnOnce(&Collider) -> T) -> T {
+        let collider = self
             .0
-            .get_unknown_gen(handle)
+            .get(utils::collider_handle(handle))
             .expect("Invalid Collider reference. It may have been removed from the physics World.");
         f(collider)
     }
 
-    pub(crate) fn map_mut<T>(&mut self, handle: u32, f: impl FnOnce(&mut Collider) -> T) -> T {
-        let (collider, _) = self
+    pub(crate) fn map_mut<T>(
+        &mut self,
+        handle: FlatHandle,
+        f: impl FnOnce(&mut Collider) -> T,
+    ) -> T {
+        let collider = self
             .0
-            .get_unknown_gen_mut(handle)
+            .get_mut(utils::collider_handle(handle))
             .expect("Invalid Collider reference. It may have been removed from the physics World.");
         f(collider)
     }
@@ -51,9 +56,9 @@ impl RawColliderSet {
         activeHooks: u32,
         activeEvents: u32,
         hasParent: bool,
-        parent: u32,
+        parent: FlatHandle,
         bodies: &mut RawRigidBodySet,
-    ) -> Option<u32> {
+    ) -> Option<FlatHandle> {
         let pos = Isometry::from_parts(translation.0.into(), rotation.0);
         let mut builder = ColliderBuilder::new(shape.0.clone())
             .position(pos)
@@ -89,15 +94,13 @@ impl RawColliderSet {
         let collider = builder.build();
 
         if hasParent {
-            let (_, handle) = bodies.0.get_unknown_gen(parent)?;
-            Some(
+            Some(utils::fuse_handle(
                 self.0
-                    .insert_with_parent(collider, handle, &mut bodies.0)
-                    .into_raw_parts()
+                    .insert_with_parent(collider, utils::body_handle(parent), &mut bodies.0)
                     .0,
-            )
+            ))
         } else {
-            Some(self.0.insert(collider).into_raw_parts().0)
+            Some(utils::fuse_handle(self.0.insert(collider).0))
         }
     }
 }
@@ -113,8 +116,8 @@ impl RawColliderSet {
         self.0.len()
     }
 
-    pub fn contains(&self, handle: u32) -> bool {
-        self.0.get_unknown_gen(handle).is_some()
+    pub fn contains(&self, handle: FlatHandle) -> bool {
+        self.0.get(utils::collider_handle(handle)).is_some()
     }
 
     #[cfg(feature = "dim2")]
@@ -139,9 +142,9 @@ impl RawColliderSet {
         activeHooks: u32,
         activeEvents: u32,
         hasParent: bool,
-        parent: u32,
+        parent: FlatHandle,
         bodies: &mut RawRigidBodySet,
-    ) -> Option<u32> {
+    ) -> Option<FlatHandle> {
         self.do_create_collider(
             shape,
             translation,
@@ -190,9 +193,9 @@ impl RawColliderSet {
         activeHooks: u32,
         activeEvents: u32,
         hasParent: bool,
-        parent: u32,
+        parent: FlatHandle,
         bodies: &mut RawRigidBodySet,
-    ) -> Option<u32> {
+    ) -> Option<FlatHandle> {
         self.do_create_collider(
             shape,
             translation,
@@ -222,19 +225,18 @@ impl RawColliderSet {
     /// Removes a collider from this set and wake-up the rigid-body it is attached to.
     pub fn remove(
         &mut self,
-        handle: u32,
+        handle: FlatHandle,
         islands: &mut RawIslandManager,
         bodies: &mut RawRigidBodySet,
         wakeUp: bool,
     ) {
-        if let Some((_, handle)) = self.0.get_unknown_gen(handle) {
-            self.0.remove(handle, &mut islands.0, &mut bodies.0, wakeUp);
-        }
+        let handle = utils::collider_handle(handle);
+        self.0.remove(handle, &mut islands.0, &mut bodies.0, wakeUp);
     }
 
     /// Checks if a collider with the given integer handle exists.
-    pub fn isHandleValid(&self, handle: u32) -> bool {
-        self.0.get_unknown_gen(handle).is_some()
+    pub fn isHandleValid(&self, handle: FlatHandle) -> bool {
+        self.0.get(utils::collider_handle(handle)).is_some()
     }
 
     /// Applies the given JavaScript function to the integer handle of each collider managed by this collider set.
@@ -244,7 +246,7 @@ impl RawColliderSet {
     pub fn forEachColliderHandle(&self, f: &js_sys::Function) {
         let this = JsValue::null();
         for (handle, _) in self.0.iter() {
-            let _ = f.call1(&this, &JsValue::from(handle.into_raw_parts().0 as u32));
+            let _ = f.call1(&this, &JsValue::from(utils::fuse_handle(handle.0)));
         }
     }
 }

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -19,9 +19,9 @@ impl RawNarrowPhase {
         let handle1 = utils::collider_handle(handle1);
         for pair in self.0.contacts_with(handle1) {
             let handle2 = if pair.collider1 == handle1 {
-                utils::fuse_handle(pair.collider2.0)
+                utils::flat_handle(pair.collider2.0)
             } else {
-                utils::fuse_handle(pair.collider1.0)
+                utils::flat_handle(pair.collider1.0)
             };
 
             let _ = f.call1(&this, &JsValue::from(handle2));
@@ -42,9 +42,9 @@ impl RawNarrowPhase {
         for (h1, h2, inter) in self.0.intersections_with(handle1) {
             if inter {
                 let handle2 = if h1 == handle1 {
-                    utils::fuse_handle(h2.0)
+                    utils::flat_handle(h2.0)
                 } else {
-                    utils::fuse_handle(h1.0)
+                    utils::flat_handle(h1.0)
                 };
 
                 let _ = f.call1(&this, &JsValue::from(handle2));
@@ -70,11 +70,11 @@ pub struct RawContactManifold(*const ContactManifold);
 #[wasm_bindgen]
 impl RawContactPair {
     pub fn collider1(&self) -> FlatHandle {
-        unsafe { utils::fuse_handle((*self.0).collider1.0) }
+        unsafe { utils::flat_handle((*self.0).collider1.0) }
     }
 
     pub fn collider2(&self) -> FlatHandle {
-        unsafe { utils::fuse_handle((*self.0).collider2.0) }
+        unsafe { utils::flat_handle((*self.0).collider2.0) }
     }
 
     pub fn numContactManifolds(&self) -> usize {

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -32,7 +32,7 @@ pub struct RawPointColliderProjection {
 #[wasm_bindgen]
 impl RawPointColliderProjection {
     pub fn colliderHandle(&self) -> FlatHandle {
-        utils::fuse_handle(self.handle.0)
+        utils::flat_handle(self.handle.0)
     }
 
     pub fn point(&self) -> RawVector {

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -1,6 +1,7 @@
 use crate::geometry::feature::IntoTypeValue;
 use crate::geometry::RawFeatureType;
 use crate::math::RawVector;
+use crate::utils::{self, FlatHandle};
 use rapier::{
     geometry::{ColliderHandle, PointProjection},
     prelude::FeatureId,
@@ -30,8 +31,8 @@ pub struct RawPointColliderProjection {
 
 #[wasm_bindgen]
 impl RawPointColliderProjection {
-    pub fn colliderHandle(&self) -> u32 {
-        self.handle.into_raw_parts().0
+    pub fn colliderHandle(&self) -> FlatHandle {
+        utils::fuse_handle(self.handle.0)
     }
 
     pub fn point(&self) -> RawVector {

--- a/src/geometry/ray.rs
+++ b/src/geometry/ray.rs
@@ -1,6 +1,7 @@
 use crate::geometry::feature::IntoTypeValue;
 use crate::geometry::RawFeatureType;
 use crate::math::RawVector;
+use crate::utils::{self, FlatHandle};
 use rapier::geometry::{ColliderHandle, RayIntersection};
 use wasm_bindgen::prelude::*;
 
@@ -34,8 +35,8 @@ pub struct RawRayColliderIntersection {
 
 #[wasm_bindgen]
 impl RawRayColliderIntersection {
-    pub fn colliderHandle(&self) -> u32 {
-        self.handle.into_raw_parts().0
+    pub fn colliderHandle(&self) -> FlatHandle {
+        utils::fuse_handle(self.handle.0)
     }
 
     pub fn normal(&self) -> RawVector {
@@ -63,8 +64,8 @@ pub struct RawRayColliderToi {
 
 #[wasm_bindgen]
 impl RawRayColliderToi {
-    pub fn colliderHandle(&self) -> u32 {
-        self.handle.into_raw_parts().0
+    pub fn colliderHandle(&self) -> FlatHandle {
+        utils::fuse_handle(self.handle.0)
     }
 
     pub fn toi(&self) -> f32 {

--- a/src/geometry/ray.rs
+++ b/src/geometry/ray.rs
@@ -36,7 +36,7 @@ pub struct RawRayColliderIntersection {
 #[wasm_bindgen]
 impl RawRayColliderIntersection {
     pub fn colliderHandle(&self) -> FlatHandle {
-        utils::fuse_handle(self.handle.0)
+        utils::flat_handle(self.handle.0)
     }
 
     pub fn normal(&self) -> RawVector {
@@ -65,7 +65,7 @@ pub struct RawRayColliderToi {
 #[wasm_bindgen]
 impl RawRayColliderToi {
     pub fn colliderHandle(&self) -> FlatHandle {
-        utils::fuse_handle(self.handle.0)
+        utils::flat_handle(self.handle.0)
     }
 
     pub fn toi(&self) -> f32 {

--- a/src/geometry/toi.rs
+++ b/src/geometry/toi.rs
@@ -40,7 +40,7 @@ pub struct RawShapeColliderTOI {
 #[wasm_bindgen]
 impl RawShapeColliderTOI {
     pub fn colliderHandle(&self) -> FlatHandle {
-        utils::fuse_handle(self.handle.0)
+        utils::flat_handle(self.handle.0)
     }
 
     pub fn toi(&self) -> f32 {

--- a/src/geometry/toi.rs
+++ b/src/geometry/toi.rs
@@ -1,4 +1,5 @@
 use crate::math::RawVector;
+use crate::utils::{self, FlatHandle};
 use rapier::geometry::{ColliderHandle, TOI};
 use wasm_bindgen::prelude::*;
 
@@ -38,8 +39,8 @@ pub struct RawShapeColliderTOI {
 
 #[wasm_bindgen]
 impl RawShapeColliderTOI {
-    pub fn colliderHandle(&self) -> u32 {
-        self.handle.into_raw_parts().0
+    pub fn colliderHandle(&self) -> FlatHandle {
+        utils::fuse_handle(self.handle.0)
     }
 
     pub fn toi(&self) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,4 @@ pub mod dynamics;
 pub mod geometry;
 pub mod math;
 pub mod pipeline;
+pub mod utils;

--- a/src/pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline.rs
@@ -1,5 +1,5 @@
 use crate::dynamics::{RawImpulseJointSet, RawMultibodyJointSet, RawRigidBodySet};
-use crate::geometry::RawColliderSet;
+use crate::geometry::{RawColliderSet, RawNarrowPhase};
 use js_sys::Float32Array;
 use palette::convert::IntoColorUnclamped;
 use palette::rgb::Rgba;
@@ -44,6 +44,7 @@ impl RawDebugRenderPipeline {
         colliders: &RawColliderSet,
         impulse_joints: &RawImpulseJointSet,
         multibody_joints: &RawMultibodyJointSet,
+        narrow_phase: &RawNarrowPhase,
     ) {
         self.vertices.clear();
         self.colors.clear();
@@ -58,6 +59,7 @@ impl RawDebugRenderPipeline {
             &colliders.0,
             &impulse_joints.0,
             &multibody_joints.0,
+            &narrow_phase.0,
         )
     }
 }

--- a/src/pipeline/event_queue.rs
+++ b/src/pipeline/event_queue.rs
@@ -58,8 +58,8 @@ impl RawEventQueue {
         while let Ok(event) = self.collision_events.try_recv() {
             match event {
                 CollisionEvent::Started(co1, co2, _) => {
-                    let h1 = utils::fuse_handle(co1.0);
-                    let h2 = utils::fuse_handle(co2.0);
+                    let h1 = utils::flat_handle(co1.0);
+                    let h2 = utils::flat_handle(co2.0);
                     let _ = f.call3(
                         &this,
                         &JsValue::from(h1),
@@ -68,8 +68,8 @@ impl RawEventQueue {
                     );
                 }
                 CollisionEvent::Stopped(co1, co2, _) => {
-                    let h1 = utils::fuse_handle(co1.0);
-                    let h2 = utils::fuse_handle(co2.0);
+                    let h1 = utils::flat_handle(co1.0);
+                    let h2 = utils::flat_handle(co2.0);
                     let _ = f.call3(
                         &this,
                         &JsValue::from(h1),

--- a/src/pipeline/event_queue.rs
+++ b/src/pipeline/event_queue.rs
@@ -1,3 +1,4 @@
+use crate::utils;
 use rapier::crossbeam::channel::Receiver;
 use rapier::geometry::CollisionEvent;
 use rapier::pipeline::ChannelEventCollector;
@@ -57,8 +58,8 @@ impl RawEventQueue {
         while let Ok(event) = self.collision_events.try_recv() {
             match event {
                 CollisionEvent::Started(co1, co2, _) => {
-                    let h1 = co1.into_raw_parts().0 as u32;
-                    let h2 = co2.into_raw_parts().0 as u32;
+                    let h1 = utils::fuse_handle(co1.0);
+                    let h2 = utils::fuse_handle(co2.0);
                     let _ = f.call3(
                         &this,
                         &JsValue::from(h1),
@@ -67,8 +68,8 @@ impl RawEventQueue {
                     );
                 }
                 CollisionEvent::Stopped(co1, co2, _) => {
-                    let h1 = co1.into_raw_parts().0 as u32;
-                    let h2 = co2.into_raw_parts().0 as u32;
+                    let h1 = utils::fuse_handle(co1.0);
+                    let h2 = utils::fuse_handle(co2.0);
                     let _ = f.call3(
                         &this,
                         &JsValue::from(h1),

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -22,19 +22,19 @@ impl PhysicsHooks for RawPhysicsHooks {
     fn filter_contact_pair(&self, ctxt: &PairFilterContext) -> Option<SolverFlags> {
         let rb1 = ctxt
             .rigid_body1
-            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
+            .map(|rb| JsValue::from(utils::flat_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
         let rb2 = ctxt
             .rigid_body2
-            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
+            .map(|rb| JsValue::from(utils::flat_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
 
         let result = self
             .filter_contact_pair
             .bind2(
                 &self.this,
-                &JsValue::from(utils::fuse_handle(ctxt.collider1.0)),
-                &JsValue::from(utils::fuse_handle(ctxt.collider2.0)),
+                &JsValue::from(utils::flat_handle(ctxt.collider1.0)),
+                &JsValue::from(utils::flat_handle(ctxt.collider2.0)),
             )
             .call2(&self.this, &rb1, &rb2)
             .ok()?;
@@ -47,18 +47,18 @@ impl PhysicsHooks for RawPhysicsHooks {
     fn filter_intersection_pair(&self, ctxt: &PairFilterContext) -> bool {
         let rb1 = ctxt
             .rigid_body1
-            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
+            .map(|rb| JsValue::from(utils::flat_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
         let rb2 = ctxt
             .rigid_body2
-            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
+            .map(|rb| JsValue::from(utils::flat_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
 
         self.filter_intersection_pair
             .bind2(
                 &self.this,
-                &JsValue::from(utils::fuse_handle(ctxt.collider1.0)),
-                &JsValue::from(utils::fuse_handle(ctxt.collider2.0)),
+                &JsValue::from(utils::flat_handle(ctxt.collider1.0)),
+                &JsValue::from(utils::flat_handle(ctxt.collider2.0)),
             )
             .call2(&self.this, &rb1, &rb2)
             .ok()

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -1,3 +1,4 @@
+use crate::utils;
 use rapier::geometry::SolverFlags;
 use rapier::pipeline::{ContactModificationContext, PairFilterContext, PhysicsHooks};
 use wasm_bindgen::prelude::*;
@@ -21,19 +22,19 @@ impl PhysicsHooks for RawPhysicsHooks {
     fn filter_contact_pair(&self, ctxt: &PairFilterContext) -> Option<SolverFlags> {
         let rb1 = ctxt
             .rigid_body1
-            .map(|rb| JsValue::from(rb.into_raw_parts().0))
+            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
         let rb2 = ctxt
             .rigid_body2
-            .map(|rb| JsValue::from(rb.into_raw_parts().0))
+            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
 
         let result = self
             .filter_contact_pair
             .bind2(
                 &self.this,
-                &JsValue::from(ctxt.collider1.into_raw_parts().0),
-                &JsValue::from(ctxt.collider2.into_raw_parts().0),
+                &JsValue::from(utils::fuse_handle(ctxt.collider1.0)),
+                &JsValue::from(utils::fuse_handle(ctxt.collider2.0)),
             )
             .call2(&self.this, &rb1, &rb2)
             .ok()?;
@@ -46,18 +47,18 @@ impl PhysicsHooks for RawPhysicsHooks {
     fn filter_intersection_pair(&self, ctxt: &PairFilterContext) -> bool {
         let rb1 = ctxt
             .rigid_body1
-            .map(|rb| JsValue::from(rb.into_raw_parts().0))
+            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
         let rb2 = ctxt
             .rigid_body2
-            .map(|rb| JsValue::from(rb.into_raw_parts().0))
+            .map(|rb| JsValue::from(utils::fuse_handle(rb.0)))
             .unwrap_or(JsValue::NULL);
 
         self.filter_intersection_pair
             .bind2(
                 &self.this,
-                &JsValue::from(ctxt.collider1.into_raw_parts().0),
-                &JsValue::from(ctxt.collider2.into_raw_parts().0),
+                &JsValue::from(utils::fuse_handle(ctxt.collider1.0)),
+                &JsValue::from(utils::fuse_handle(ctxt.collider2.0)),
             )
             .call2(&self.this, &rb1, &rb2)
             .ok()

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -4,6 +4,7 @@ use crate::geometry::{
     RawShape, RawShapeColliderTOI,
 };
 use crate::math::{RawRotation, RawVector};
+use crate::utils::{self, FlatHandle};
 use rapier::geometry::{ColliderHandle, Ray, AABB};
 use rapier::math::{Isometry, Point};
 use rapier::pipeline::QueryPipeline;
@@ -128,7 +129,7 @@ impl RawQueryPipeline {
         shape: &RawShape,
         groups: u32,
         filter: &js_sys::Function,
-    ) -> Option<u32> {
+    ) -> Option<FlatHandle> {
         let rfilter = wrap_filter(filter);
         let rfilter = rfilter
             .as_ref()
@@ -143,7 +144,7 @@ impl RawQueryPipeline {
                 crate::geometry::unpack_interaction_groups(groups),
                 rfilter,
             )
-            .map(|h| h.into_raw_parts().0)
+            .map(|h| utils::fuse_handle(h.0))
     }
 
     pub fn projectPoint(
@@ -205,7 +206,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(handle.into_raw_parts().0 as u32),
+            &JsValue::from(utils::fuse_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -267,7 +268,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(handle.into_raw_parts().0 as u32),
+            &JsValue::from(utils::fuse_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -297,7 +298,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: &ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(handle.into_raw_parts().0 as u32),
+            &JsValue::from(utils::fuse_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -315,7 +316,7 @@ fn wrap_filter(filter: &js_sys::Function) -> Option<impl Fn(ColliderHandle) -> b
     if filter.is_function() {
         let filtercb = move |handle: ColliderHandle| match filter.call1(
             &JsValue::null(),
-            &JsValue::from(handle.into_raw_parts().0 as u32),
+            &JsValue::from(utils::fuse_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -144,7 +144,7 @@ impl RawQueryPipeline {
                 crate::geometry::unpack_interaction_groups(groups),
                 rfilter,
             )
-            .map(|h| utils::fuse_handle(h.0))
+            .map(|h| utils::flat_handle(h.0))
     }
 
     pub fn projectPoint(
@@ -206,7 +206,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(utils::fuse_handle(handle.0)),
+            &JsValue::from(utils::flat_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -268,7 +268,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(utils::fuse_handle(handle.0)),
+            &JsValue::from(utils::flat_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -298,7 +298,7 @@ impl RawQueryPipeline {
     ) {
         let rcallback = |handle: &ColliderHandle| match callback.call1(
             &JsValue::null(),
-            &JsValue::from(utils::fuse_handle(handle.0)),
+            &JsValue::from(utils::flat_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),
@@ -316,7 +316,7 @@ fn wrap_filter(filter: &js_sys::Function) -> Option<impl Fn(ColliderHandle) -> b
     if filter.is_function() {
         let filtercb = move |handle: ColliderHandle| match filter.call1(
             &JsValue::null(),
-            &JsValue::from(utils::fuse_handle(handle.0)),
+            &JsValue::from(utils::flat_handle(handle.0)),
         ) {
             Err(_) => true,
             Ok(val) => val.as_bool().unwrap_or(true),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,31 @@
+use rapier::data::Index;
+use rapier::dynamics::{ImpulseJointHandle, MultibodyJointHandle, RigidBodyHandle};
+use rapier::geometry::ColliderHandle;
+
+pub type FlatHandle = f64;
+
+#[inline(always)]
+pub fn collider_handle(id: FlatHandle) -> ColliderHandle {
+    ColliderHandle::from_raw_parts(id.to_bits() as u32, (id.to_bits() >> 32) as u32)
+}
+
+#[inline(always)]
+pub fn body_handle(id: FlatHandle) -> RigidBodyHandle {
+    RigidBodyHandle::from_raw_parts(id.to_bits() as u32, (id.to_bits() >> 32) as u32)
+}
+
+#[inline(always)]
+pub fn impulse_joint_handle(id: FlatHandle) -> ImpulseJointHandle {
+    ImpulseJointHandle::from_raw_parts(id.to_bits() as u32, (id.to_bits() >> 32) as u32)
+}
+
+#[inline(always)]
+pub fn multibody_joint_handle(id: FlatHandle) -> MultibodyJointHandle {
+    MultibodyJointHandle::from_raw_parts(id.to_bits() as u32, (id.to_bits() >> 32) as u32)
+}
+
+#[inline(always)]
+pub fn fuse_handle(id: Index) -> FlatHandle {
+    let (i, g) = id.into_raw_parts();
+    FlatHandle::from_bits(i as u64 | ((g as u64) << 32))
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ pub fn multibody_joint_handle(id: FlatHandle) -> MultibodyJointHandle {
 }
 
 #[inline(always)]
-pub fn fuse_handle(id: Index) -> FlatHandle {
+pub fn flat_handle(id: Index) -> FlatHandle {
     let (i, g) = id.into_raw_parts();
     FlatHandle::from_bits(i as u64 | ((g as u64) << 32))
 }

--- a/testbed3d/src/demos/ccd.js
+++ b/testbed3d/src/demos/ccd.js
@@ -15,7 +15,7 @@ function createWall(RAPIER, testbed, world, offset, stackHeight, ) {
                 .setTranslation(x, y, z);
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(0.5, 0.5, 1.0);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
     }
 }
@@ -30,7 +30,7 @@ export function initWorld(RAPIER, testbed) {
     let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(30.0, 0.1, 30.0);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     let numX = 5;
     let numZ = 8;
@@ -51,7 +51,7 @@ export function initWorld(RAPIER, testbed) {
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.ball(1.0)
         .setDensity(10.0);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
 
     testbed.setWorld(world);

--- a/testbed3d/src/demos/collisionGroups.js
+++ b/testbed3d/src/demos/collisionGroups.js
@@ -6,7 +6,7 @@ export function initWorld(RAPIER, testbed) {
     let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
     let groundBody = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(5.0, 0.1, 5.0);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     // Setup groups.
     let group1 = 0x00010001;
@@ -16,13 +16,13 @@ export function initWorld(RAPIER, testbed) {
     colliderDesc = RAPIER.ColliderDesc.cuboid(1.0, 0.1, 1.0)
         .setTranslation(0.0, 1.0, 0.0)
         .setCollisionGroups(group1);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     // Add one floor that collides with the second group only.
     colliderDesc = RAPIER.ColliderDesc.cuboid(1.0, 0.1, 1.0)
         .setTranslation(0.0, 2.0, 0.0)
         .setCollisionGroups(group2);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     // Dynamic cubes.
     let num = 8;
@@ -47,7 +47,7 @@ export function initWorld(RAPIER, testbed) {
                 let body = world.createRigidBody(bodyDesc);
                 colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad)
                     .setCollisionGroups(group);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }

--- a/testbed3d/src/demos/convexPolyhedron.js
+++ b/testbed3d/src/demos/convexPolyhedron.js
@@ -45,7 +45,7 @@ export function initWorld(RAPIER, testbed) {
     let body = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 40.0, 4.0, 40.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * Create the polyhedra
@@ -79,7 +79,7 @@ export function initWorld(RAPIER, testbed) {
                 bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y, z);
                 body = world.createRigidBody(bodyDesc);
                 colliderDesc = RAPIER.ColliderDesc.roundConvexHull(vertices, border_rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }

--- a/testbed3d/src/demos/damping.js
+++ b/testbed3d/src/demos/damping.js
@@ -26,7 +26,7 @@ export function initWorld(RAPIER, testbed) {
 
         // Build the collider.
         let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-        world.createCollider(colliderDesc, body.handle);
+        world.createCollider(colliderDesc, body);
     }
 
     testbed.setWorld(world);

--- a/testbed3d/src/demos/fountain.js
+++ b/testbed3d/src/demos/fountain.js
@@ -7,7 +7,7 @@ export function initWorld(RAPIER, testbed) {
     let groundBodyDesc = RAPIER.RigidBodyDesc.newStatic();
     let groundBody = world.createRigidBody(groundBodyDesc);
     let groundColliderDesc = RAPIER.ColliderDesc.cuboid(40.0, 0.1, 40.0);
-    world.createCollider(groundColliderDesc, groundBody.handle);
+    world.createCollider(groundColliderDesc, groundBody);
 
     // Dynamic cubes.
     let rad = 1.0;
@@ -45,10 +45,10 @@ export function initWorld(RAPIER, testbed) {
         }
 
         let body = world.createRigidBody(bodyDesc);
-        let collider = world.createCollider(colliderDesc, body.handle);
+        let collider = world.createCollider(colliderDesc, body);
         graphics.addCollider(RAPIER, world, collider);
 
-        removableBodies.push(body.handle);
+        removableBodies.push(body);
 
         // We reached the max number, delete the oldest rigid-body.
         if (removableBodies.length > 400) {

--- a/testbed3d/src/demos/heightfield.js
+++ b/testbed3d/src/demos/heightfield.js
@@ -26,7 +26,7 @@ export function initWorld(RAPIER, testbed) {
     let body = world.createRigidBody(bodyDesc);
     let heights = generateHeightfield(nsubdivs)
     let colliderDesc = RAPIER.ColliderDesc.heightfield(nsubdivs, nsubdivs, heights, scale);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     // Dynamic cubes.
     let num = 4;
@@ -71,16 +71,16 @@ export function initWorld(RAPIER, testbed) {
                         break;
                     case 4:
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad / 2.0, rad / 2.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(rad, 0.0, 0.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(-rad, 0.0, 0.0);
                         break;
                 }
 
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
 

--- a/testbed3d/src/demos/joints.js
+++ b/testbed3d/src/demos/joints.js
@@ -11,7 +11,7 @@ function createPrismaticJoints(
         .setTranslation(origin.x, origin.y, origin.z);
     let currParent = world.createRigidBody(groundDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-    world.createCollider(colliderDesc, currParent.handle);
+    world.createCollider(colliderDesc, currParent);
 
     let i;
     let z;
@@ -22,7 +22,7 @@ function createPrismaticJoints(
             .setTranslation(origin.x, origin.y, z);
         let currChild = world.createRigidBody(rigidBodyDesc);
         let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-        world.createCollider(colliderDesc, currChild.handle);
+        world.createCollider(colliderDesc, currChild);
 
         let axis;
 
@@ -60,7 +60,7 @@ function createRevoluteJoints(
         .setTranslation(origin.x, origin.y, 0.0);
     let currParent = world.createRigidBody(groundDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-    world.createCollider(colliderDesc, currParent.handle);
+    world.createCollider(colliderDesc, currParent);
 
     let i, k;
     let z;
@@ -83,7 +83,7 @@ function createRevoluteJoints(
                 .setTranslation(positions[k].x, positions[k].y, positions[k].z);
             let rigidBody = world.createRigidBody(rigidBodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-            world.createCollider(colliderDesc, rigidBody.handle);
+            world.createCollider(colliderDesc, rigidBody);
 
             parents[k] = rigidBody;
         }
@@ -141,7 +141,7 @@ function createFixedJoints(
                 .setTranslation(origin.x + fk * shift, origin.y, origin.z + fi * shift);
             let child = world.createRigidBody(rigidBody);
             let colliderDesc = RAPIER.ColliderDesc.ball(rad);
-            world.createCollider(colliderDesc, child.handle);
+            world.createCollider(colliderDesc, child);
 
             // Vertical joint.
             if (i > 0) {
@@ -203,7 +203,7 @@ function createBallJoints(
                 .setTranslation(fk * shift, 0.0, fi * shift);
             let child = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.ball(rad);
-            world.createCollider(colliderDesc, child.handle);
+            world.createCollider(colliderDesc, child);
 
             // Vertical joint.
             let o = new RAPIER.Vector3(0.0, 0.0, 0.0);

--- a/testbed3d/src/demos/keva.js
+++ b/testbed3d/src/demos/keva.js
@@ -36,7 +36,7 @@ function buildBlock(
                     );
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc = RAPIER.ColliderDesc.cuboid(dim.x, dim.y, dim.z);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }
@@ -55,7 +55,7 @@ function buildBlock(
                 );
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(dim.x, dim.y, dim.z);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
     }
 }
@@ -72,7 +72,7 @@ export function initWorld(RAPIER, testbed) {
         .setTranslation(0.0, -groundHeight, 0.0);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(groundSize, groundHeight, groundSize);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     // Keva tower.
     let halfExtents = new RAPIER.Vector3(0.1, 0.5, 2.0);

--- a/testbed3d/src/demos/lockedRotations.js
+++ b/testbed3d/src/demos/lockedRotations.js
@@ -12,7 +12,7 @@ export function initWorld(RAPIER, testbed) {
         .setTranslation(0.0, -ground_height, 0.0);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(ground_size, ground_height, ground_size);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * A rectangle that only rotates along the `x` axis.
@@ -23,7 +23,7 @@ export function initWorld(RAPIER, testbed) {
         .restrictRotations(true, false, false);
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.cuboid(0.2, 0.6, 2.0);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
 
     /*
@@ -34,7 +34,7 @@ export function initWorld(RAPIER, testbed) {
         .lockRotations();
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.cylinder(0.6, 0.4);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * Setup the testbed.

--- a/testbed3d/src/demos/platform.js
+++ b/testbed3d/src/demos/platform.js
@@ -45,7 +45,7 @@ export function initWorld(RAPIER, testbed) {
     let platformBody = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 70.0, 4.0, 70.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
-    world.createCollider(colliderDesc, platformBody.handle);
+    world.createCollider(colliderDesc, platformBody);
     let t = 0.0;
 
     let movePlatform = () => {
@@ -99,16 +99,16 @@ export function initWorld(RAPIER, testbed) {
                         break;
                     case 4:
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad / 2.0, rad / 2.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(rad, 0.0, 0.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(-rad, 0.0, 0.0);
                         break;
                 }
 
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
 

--- a/testbed3d/src/demos/pyramid.js
+++ b/testbed3d/src/demos/pyramid.js
@@ -6,7 +6,7 @@ export function initWorld(RAPIER, testbed) {
     let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(30.0, 0.1, 30.0);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     // Dynamic cubes.
     let rad = 0.5;
@@ -30,7 +30,7 @@ export function initWorld(RAPIER, testbed) {
                     .setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }

--- a/testbed3d/src/demos/trimesh.js
+++ b/testbed3d/src/demos/trimesh.js
@@ -45,7 +45,7 @@ export function initWorld(RAPIER, testbed) {
     let body = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 70.0, 4.0, 70.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     // Dynamic cubes.
     let num = 4;
@@ -90,16 +90,16 @@ export function initWorld(RAPIER, testbed) {
                         break;
                     case 4:
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad / 2.0, rad / 2.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(rad, 0.0, 0.0);
-                        world.createCollider(colliderDesc, body.handle);
+                        world.createCollider(colliderDesc, body);
                         colliderDesc = RAPIER.ColliderDesc.cuboid(rad / 2.0, rad, rad / 2.0)
                             .setTranslation(-rad, 0.0, 0.0);
                         break;
                 }
 
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
 


### PR DESCRIPTION
Before, it was quite easy to mistake a collider handle and rigid-body handle (even with TS since they both had the same `number` types). In addition, since these handles were recycled, some handles of new colliders could be identical to the handle of a collider that was previously removed. Thous could yield to tricky ABA-related bugs on the user side.

This PR brings a few improvements related to handles:
- All handles are now generational handles, meaning that they are unique within each set. A collider can still have the same handle as a rigid-body, but it is not possible for a new rigid-body to have the same handle as a rigid-body that was previously removed.
- Most of the API has been modified to use `RigidBody`, `Collider`, `ImpulseJoint`, `MultibodyJoint`, objects instead of handles. For example `world.createCollider` takes the parent rigid-body objects instead of its handle as its second argument. The only places where the user has to deal with handles explicitly are within collision events and physics hooks (as well as in all the low-level structures like the `Raw` structures, and the ones used by the `World`, though these should almost never be used directly by the user).
- Joints objects are now cached the same way we cache the rigid-body and collider objects.