### PR TITLE
Ensure that the iteration orders remain the same after deserialization

### DIFF
--- a/src.ts/coarena.ts
+++ b/src.ts/coarena.ts
@@ -1,0 +1,62 @@
+export class Coarena<T> {
+    data: Array<T>
+    size: number
+
+    public constructor() {
+        this.data = new Array<T>();
+        this.size = 0;
+    }
+
+    public set(handle: number, data: T) {
+        let i = index(handle);
+        while (this.data.length <= i) {
+            this.data.push(null);
+        }
+
+        if (this.data[i] == null)
+            this.size += 1;
+        this.data[i] = data;
+    }
+
+    public len(): number {
+        return this.size;
+    }
+
+    public delete(handle: number) {
+        let i = index(handle);
+        if (this.data.length < i) {
+            if (this.data[i] != null)
+                this.size -= 1;
+            this.data[i] = null;
+        }
+    }
+
+    public clear() {
+        this.data = new Array<T>();
+    }
+
+    public get(handle: number): T | null {
+        let i = index(handle);
+        if (i < this.data.length) {
+            return this.data[i];
+        } else {
+            return null;
+        }
+    }
+
+    public forEach(f: (elt: T) => void) {
+        for (const elt of this.data) {
+            if (elt != null)
+                f(elt);
+        }
+    }
+
+    public getAll(): Array<T> {
+        return this.data.filter((elt) => elt != null);
+    }
+}
+
+/// Extracts the index part of an handle (the lower 32 bits).
+function index(handle: number): number {
+    return handle & 0x0000_0000_ffff_ffff;
+}

--- a/src.ts/coarena.ts
+++ b/src.ts/coarena.ts
@@ -1,14 +1,18 @@
 export class Coarena<T> {
+    fconv: Float64Array
+    uconv: Uint32Array
     data: Array<T>
     size: number
 
     public constructor() {
+        this.fconv = new Float64Array(1);
+        this.uconv = new Uint32Array(this.fconv.buffer);
         this.data = new Array<T>();
         this.size = 0;
     }
 
     public set(handle: number, data: T) {
-        let i = index(handle);
+        let i = this.index(handle);
         while (this.data.length <= i) {
             this.data.push(null);
         }
@@ -23,8 +27,8 @@ export class Coarena<T> {
     }
 
     public delete(handle: number) {
-        let i = index(handle);
-        if (this.data.length < i) {
+        let i = this.index(handle);
+        if (i < this.data.length) {
             if (this.data[i] != null)
                 this.size -= 1;
             this.data[i] = null;
@@ -36,7 +40,7 @@ export class Coarena<T> {
     }
 
     public get(handle: number): T | null {
-        let i = index(handle);
+        let i = this.index(handle);
         if (i < this.data.length) {
             return this.data[i];
         } else {
@@ -54,9 +58,17 @@ export class Coarena<T> {
     public getAll(): Array<T> {
         return this.data.filter((elt) => elt != null);
     }
+
+    private index(handle: number): number {
+        /// Extracts the index part of a handle (the lower 32 bits).
+        /// This is done by first injecting the handle into an Float64Array
+        /// which is itself injected into an Uint32Array (at construction time).
+        /// The 0-th value of the Uint32Array will become the `number` integer
+        /// representation of the lower 32 bits.
+        /// Also `this.uconv[1]` then contains the generation number as a `number`,
+        /// which we don’t really need.
+        this.fconv[0] = handle;
+        return this.uconv[0];
+    }
 }
 
-/// Extracts the index part of an handle (the lower 32 bits).
-function index(handle: number): number {
-    return handle & 0x0000_0000_ffff_ffff;
-}

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -1,4 +1,5 @@
 import {RawMultibodyJointSet} from "../raw"
+import {Coarena} from "../coarena"
 import {RigidBodySet} from "./rigid_body_set";
 import {
     MultibodyJoint,
@@ -26,7 +27,7 @@ import {RigidBodyHandle} from "./rigid_body";
  */
 export class MultibodyJointSet {
     raw: RawMultibodyJointSet;
-    private map: Map<MultibodyJointHandle, MultibodyJoint>
+    private map: Coarena<MultibodyJoint>
 
     /**
      * Release the WASM memory occupied by this joint set.
@@ -40,7 +41,7 @@ export class MultibodyJointSet {
 
     constructor(raw?: RawMultibodyJointSet) {
         this.raw = raw || new RawMultibodyJointSet();
-        this.map = new Map();
+        this.map = new Coarena<MultibodyJoint>();
         // Initialize the map with the existing elements, if any.
         if (raw) {
             raw.forEachJointHandle((handle: MultibodyJointHandle) => {
@@ -94,7 +95,7 @@ export class MultibodyJointSet {
      * The number of joints on this set.
      */
     public len(): number {
-        return this.map.size;
+        return this.map.len();
     }
 
     /**
@@ -103,19 +104,17 @@ export class MultibodyJointSet {
      * @param handle - The joint handle to check.
      */
     public contains(handle: MultibodyJointHandle): boolean {
-        return this.map.has(handle);
+        return this.get(handle) != null;
     }
 
     /**
      * Gets the joint with the given handle.
      *
      * Returns `null` if no joint with the specified handle exists.
-     * Note that two distinct calls with the same `handle` will return two
-     * different JavaScript objects that both represent the same joint.
      *
      * @param handle - The integer handle of the joint to retrieve.
      */
-    public get(handle: MultibodyJointHandle): MultibodyJoint {
+    public get(handle: MultibodyJointHandle): MultibodyJoint  | null {
         return this.map.get(handle);
     }
 
@@ -124,19 +123,8 @@ export class MultibodyJointSet {
      *
      * @param f - The closure to apply.
      */
-    public forEachJoint(f: (joint: MultibodyJoint) => void) {
-        for (const joint of this.map.values())
-            f(joint);
-    }
-
-    /**
-     * Applies the given closure to the handle of each joint contained by this set.
-     *
-     * @param f - The closure to apply.
-     */
-    public forEachJointHandle(f: (handle: MultibodyJointHandle) => void) {
-        for (const key of this.map.keys())
-            f(key);
+    public forEach(f: (joint: MultibodyJoint) => void) {
+        this.map.forEach(f);
     }
 
     /**
@@ -149,20 +137,11 @@ export class MultibodyJointSet {
     }
 
     /**
-     * Gets all handles of the joints in the list.
-     *
-     * @returns joint handle list.
-     */
-    public getAllHandles(): MultibodyJointHandle[] {
-        return Array.from(this.map.keys());
-    }
-
-    /**
      * Gets all joints in the list.
      *
      * @returns joint list.
      */
-    public getAllJoints(): MultibodyJoint[] {
-        return Array.from(this.map.values());
+    public getAll(): MultibodyJoint[] {
+        return this.map.getAll();
     }
 }

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -19,7 +19,7 @@ import { Ray, RayIntersection } from "./ray";
 import { PointProjection } from "./point";
 import { ShapeColliderTOI, ShapeTOI } from "./toi";
 import { ShapeContact } from "./contact";
-import {ColliderSet} from "./collider_set";
+import { ColliderSet } from "./collider_set";
 
 /// Flags affecting whether or not collision-detection happens between two colliders
 /// depending on the type of rigid-bodies they are attached to.

--- a/src.ts/geometry/collider_set.ts
+++ b/src.ts/geometry/collider_set.ts
@@ -46,7 +46,7 @@ export class ColliderSet {
      *
      * @param bodies - The set of bodies where the collider's parent can be found.
      * @param desc - The collider's description.
-     * @param parentHandle - The inteer handle of the rigid-body this collider is attached to.
+     * @param parentHandle - The integer handle of the rigid-body this collider is attached to.
      */
     public createCollider(bodies: RigidBodySet, desc: ColliderDesc, parentHandle: RigidBodyHandle): Collider {
         let hasParent = parentHandle != undefined && parentHandle != null;

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -454,16 +454,7 @@ export class World {
      * @param f(collider) - The function to apply to each collider managed by this physics world. Called as `f(collider)`.
      */
     public forEachCollider(f: (collider: Collider) => void) {
-        this.colliders.forEachCollider(f)
-    }
-
-    /**
-     * Applies the given closure to the integer handle of each collider managed by this physics world.
-     *
-     * @param f(handle) - The function to apply to the integer handle of each collider managed by this physics world. Called as `f(collider)`.
-     */
-    public forEachColliderHandle(f: (handle: ColliderHandle) => void) {
-        this.colliders.forEachColliderHandle(f)
+        this.colliders.forEach(f)
     }
 
     /**
@@ -472,16 +463,7 @@ export class World {
      * @param f(body) - The function to apply to each rigid-body managed by this physics world. Called as `f(collider)`.
      */
     public forEachRigidBody(f: (body: RigidBody) => void) {
-        this.bodies.forEachRigidBody(f)
-    }
-
-    /**
-     * Applies the given closure to the integer handle of each rigid-body managed by this physics world.
-     *
-     * @param f(handle) - The function to apply to the integer handle of each rigid-body managed by this physics world. Called as `f(collider)`.
-     */
-    public forEachRigidBodyHandle(f: (handle: RigidBodyHandle) => void) {
-        this.bodies.forEachRigidBodyHandle(f)
+        this.bodies.forEach(f)
     }
 
     /**
@@ -495,21 +477,6 @@ export class World {
      */
     public forEachActiveRigidBody(f: (body: RigidBody) => void) {
         this.bodies.forEachActiveRigidBody(this.islands, f);
-    }
-
-    /**
-     * Applies the given closure to the integer handle of each active rigid-body
-     * managed by this physics world.
-     *
-     * After a short time of inactivity, a rigid-body is automatically deactivated ("asleep") by
-     * the physics engine in order to save computational power. A sleeping rigid-body never moves
-     * unless it is moved manually by the user.
-     *
-     * @param f(handle) - The function to apply to the integer handle of each active rigid-body managed by this
-     *   physics world. Called as `f(collider)`.
-     */
-    public forEachActiveRigidBodyHandle(f: (handle: RigidBodyHandle) => void) {
-        this.islands.forEachActiveRigidBodyHandle(f);
     }
 
     /**
@@ -555,7 +522,6 @@ export class World {
     ): RayColliderIntersection | null {
         return this.queryPipeline.castRayAndGetNormal(this.colliders, ray, maxToi, solid, groups, castClosure(this.colliders, filter));
     }
-
 
     /**
      * Cast a ray and collects all the intersections between a ray and the scene.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,3 +29,31 @@ pub fn flat_handle(id: Index) -> FlatHandle {
     let (i, g) = id.into_raw_parts();
     FlatHandle::from_bits(i as u64 | ((g as u64) << 32))
 }
+
+// pub type FlatHandle = u32;
+//
+// #[inline(always)]
+// pub fn collider_handle(id: FlatHandle) -> ColliderHandle {
+//     ColliderHandle::from_raw_parts(id as u32, (id >> 16) as u32)
+// }
+//
+// #[inline(always)]
+// pub fn body_handle(id: FlatHandle) -> RigidBodyHandle {
+//     RigidBodyHandle::from_raw_parts(id as u32, (id >> 16) as u32)
+// }
+//
+// #[inline(always)]
+// pub fn impulse_joint_handle(id: FlatHandle) -> ImpulseJointHandle {
+//     ImpulseJointHandle::from_raw_parts(id as u32, (id >> 16) as u32)
+// }
+//
+// #[inline(always)]
+// pub fn multibody_joint_handle(id: FlatHandle) -> MultibodyJointHandle {
+//     MultibodyJointHandle::from_raw_parts(id as u32, (id >> 16) as u32)
+// }
+//
+// #[inline(always)]
+// pub fn flat_handle(id: Index) -> FlatHandle {
+//     let (i, g) = id.into_raw_parts();
+//     i as u32 | ((g as u32) << 16)
+// }

--- a/testbed2d/src/Graphics.js
+++ b/testbed2d/src/Graphics.js
@@ -140,7 +140,7 @@ export class Graphics {
 
     addCollider(RAPIER, world, collider) {
         let i;
-        let parent = world.getRigidBody(collider.parent());
+        let parent = collider.parent();
         let instance;
         let graphics;
         let vertices;

--- a/testbed2d/src/demos/collisionGroups.js
+++ b/testbed2d/src/demos/collisionGroups.js
@@ -12,7 +12,7 @@ export function initWorld(RAPIER, testbed) {
         .setTranslation(0.0, -ground_height);
     let groundBody = world.createRigidBody(groundBodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(ground_size, ground_height);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     /*
      * Setup groups
@@ -26,7 +26,7 @@ export function initWorld(RAPIER, testbed) {
     colliderDesc = RAPIER.ColliderDesc.cuboid(1.0, 0.1)
         .setTranslation(0.0, 1.0)
         .setCollisionGroups(group1);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     /*
      * A blue floor that will collide with the second group only.
@@ -34,7 +34,7 @@ export function initWorld(RAPIER, testbed) {
     colliderDesc = RAPIER.ColliderDesc.cuboid(1.0, 0.1)
         .setTranslation(0.0, 2.0)
         .setCollisionGroups(group2);
-    world.createCollider(colliderDesc, groundBody.handle);
+    world.createCollider(colliderDesc, groundBody);
 
     /*
      * Create the cubes
@@ -55,11 +55,11 @@ export function initWorld(RAPIER, testbed) {
             // Alternate between the green and blue groups.
             let group = (i % 2 == 0) ? group1 : group2;
 
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y);
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad)
                 .setCollisionGroups(group);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
     }
 

--- a/testbed2d/src/demos/convexPolygons.js
+++ b/testbed2d/src/demos/convexPolygons.js
@@ -20,7 +20,7 @@ export function initWorld(RAPIER, testbed) {
             .setTranslation(ground.x, ground.y);
         let body = world.createRigidBody(bodyDesc);
         let colliderDesc = RAPIER.ColliderDesc.cuboid(ground.hx, ground.hy);
-        world.createCollider(colliderDesc, body.handle);
+        world.createCollider(colliderDesc, body);
     });
 
     /*
@@ -42,7 +42,7 @@ export function initWorld(RAPIER, testbed) {
             let x = i * shift - centerx;
             let y = j * shift * 2.0 + centery + 2.0;
 
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y);
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
 
             let points = [];
@@ -52,7 +52,7 @@ export function initWorld(RAPIER, testbed) {
             points = new Float32Array(points);
 
             let colliderDesc = RAPIER.ColliderDesc.convexHull(points);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
     }
 

--- a/testbed2d/src/demos/cubes.js
+++ b/testbed2d/src/demos/cubes.js
@@ -15,7 +15,7 @@ export function initWorld(RAPIER, testbed) {
             .setTranslation(ground.x, ground.y);
         let body = world.createRigidBody(bodyDesc);
         let colliderDesc = RAPIER.ColliderDesc.cuboid(ground.hx, ground.hy);
-        world.createCollider(colliderDesc, body.handle);
+        world.createCollider(colliderDesc, body);
     });
 
     // Dynamic cubes.
@@ -35,11 +35,11 @@ export function initWorld(RAPIER, testbed) {
             let y = j * shift + centery + 3.0;
 
             // Create dynamic cube.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                 .setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
     }
 

--- a/testbed2d/src/demos/heightfield.js
+++ b/testbed2d/src/demos/heightfield.js
@@ -19,7 +19,7 @@ export function initWorld(RAPIER, testbed) {
     let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.heightfield(heights, ground_size);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * Create the cubes
@@ -37,15 +37,15 @@ export function initWorld(RAPIER, testbed) {
             let y = j * shift + centery + 3.0;
 
             // Build the rigid body.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y);
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
 
             if (j % 2 == 0) {
                 let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             } else {
                 let colliderDesc = RAPIER.ColliderDesc.ball(rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }

--- a/testbed2d/src/demos/keva.js
+++ b/testbed2d/src/demos/keva.js
@@ -23,14 +23,14 @@ function buildBlock(
             let x = i % 2 == 0 ? spacing * j * 2.0 : dim.x * j * 2.0;
 
             // Build the rigid body.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                 .setTranslation(
                     x + dim.x + shift.x,
                     y + dim.y + shift.y,
                 );
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(dim.x, dim.y);
-            world.createCollider(colliderDesc, body.handle);
+            world.createCollider(colliderDesc, body);
         }
 
         y += dim.y * 2.0;
@@ -49,7 +49,7 @@ export function initWorld(RAPIER, testbed) {
         .setTranslation(0.0, -groundHeight, 0.0);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(groundSize, groundHeight, groundSize);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     // Keva tower.
     let halfExtents = new RAPIER.Vector2(0.5, 2.0);

--- a/testbed2d/src/demos/lockedRotations.js
+++ b/testbed2d/src/demos/lockedRotations.js
@@ -12,28 +12,28 @@ export function initWorld(RAPIER, testbed) {
         .setTranslation(0.0, -ground_height);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(ground_size, ground_height);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * A rectangle that only rotates along the `x` axis.
      */
-    bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+    bodyDesc = RAPIER.RigidBodyDesc.dynamic()
         .setTranslation(0.0, 3.0)
         .lockTranslations();
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.cuboid(2.0, 0.6);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
 
     /*
      * A cuboid that cannot rotate.
      */
-    bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+    bodyDesc = RAPIER.RigidBodyDesc.dynamic()
         .setTranslation(0.4, 5.0)
         .lockRotations();
     body = world.createRigidBody(bodyDesc);
     colliderDesc = RAPIER.ColliderDesc.cuboid(0.4, 0.6);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * Setup the testbed.

--- a/testbed2d/src/demos/polyline.js
+++ b/testbed2d/src/demos/polyline.js
@@ -23,7 +23,7 @@ export function initWorld(RAPIER, testbed) {
     let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.polyline(points);
-    world.createCollider(colliderDesc, body.handle);
+    world.createCollider(colliderDesc, body);
 
     /*
      * Create the cubes
@@ -41,15 +41,15 @@ export function initWorld(RAPIER, testbed) {
             let y = j * shift + centery + 3.0;
 
             // Build the rigid body.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y);
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
 
             if (j % 2 == 0) {
                 let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             } else {
                 let colliderDesc = RAPIER.ColliderDesc.ball(rad);
-                world.createCollider(colliderDesc, body.handle);
+                world.createCollider(colliderDesc, body);
             }
         }
     }

--- a/testbed2d/src/demos/revoluteJoints.js
+++ b/testbed2d/src/demos/revoluteJoints.js
@@ -17,7 +17,7 @@ export function initWorld(RAPIER, testbed) {
                 .setTranslation(k * shift, -i * shift);
             let child = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.ball(rad);
-            world.createCollider(colliderDesc, child.handle);
+            world.createCollider(colliderDesc, child);
 
             // Vertical joint.
             if (i > 0) {

--- a/testbed3d/src/Graphics.js
+++ b/testbed3d/src/Graphics.js
@@ -260,9 +260,9 @@ export class Graphics {
                 this.addCollider(RAPIER, world, collider);
             });
             modifications.removeRigidBody.forEach(body => {
-                if (!!this.rb2colls.get(body)) {
-                    this.rb2colls.get(body).forEach(coll => this.removeCollider(coll));
-                    this.rb2colls.delete(body);
+                if (!!this.rb2colls.get(body.handle)) {
+                    this.rb2colls.get(body.handle).forEach(coll => this.removeCollider(coll));
+                    this.rb2colls.delete(body.handle);
                 }
             });
         }
@@ -275,8 +275,8 @@ export class Graphics {
         }
     }
 
-    removeCollider(handle) {
-        let gfx = this.coll2instance.get(handle);
+    removeCollider(collider) {
+        let gfx = this.coll2instance.get(collider.handle);
         let instance = this.instanceGroups[gfx.groupId][gfx.instanceId];
 
         if (instance.count > 1) {
@@ -284,24 +284,23 @@ export class Graphics {
             instance.elementId2coll.delete(instance.count - 1);
             instance.elementId2coll.set(gfx.elementId, coll2);
 
-            let gfx2 = this.coll2instance.get(coll2);
+            let gfx2 = this.coll2instance.get(coll2.handle);
             gfx2.elementId = gfx.elementId;
         }
 
         instance.count -= 1;
-        this.coll2instance.delete(handle);
+        this.coll2instance.delete(collider.handle);
     }
 
     addCollider(RAPIER, world, collider) {
         this.colorIndex = (this.colorIndex + 1) % (this.colorPalette.length - 2);
-        let parentHandle = collider.parent();
-        if (!this.rb2colls.get(parentHandle)) {
-            this.rb2colls.set(parentHandle, [collider.handle]);
+        let parent = collider.parent();
+        if (!this.rb2colls.get(parent.handle)) {
+            this.rb2colls.set(parent.handle, [collider]);
         } else {
-            this.rb2colls.get(parentHandle).push(collider.handle);
+            this.rb2colls.get(parent.handle).push(collider);
         }
 
-        let parent = world.getRigidBody(collider.parent());
         let instance;
         let instanceDesc = {
             groupId: 0,
@@ -376,7 +375,7 @@ export class Graphics {
 
         if (!!instance) {
             instanceDesc.elementId = instance.count;
-            instance.elementId2coll.set(instance.count, collider.handle);
+            instance.elementId2coll.set(instance.count, collider);
             instance.count += 1;
         }
 

--- a/testbed3d/src/demos/ccd.js
+++ b/testbed3d/src/demos/ccd.js
@@ -11,7 +11,7 @@ function createWall(RAPIER, testbed, world, offset, stackHeight, ) {
             let z = (i * shiftZ / 2.0) + (j - i) * shiftZ + offset.z - stackHeight;
 
             // Create dynamic cube.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                 .setTranslation(x, y, z);
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(0.5, 0.5, 1.0);
@@ -27,7 +27,7 @@ export function initWorld(RAPIER, testbed) {
 
     // Create Ground.
     let groundHeight = 0.1;
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(30.0, 0.1, 30.0);
     world.createCollider(colliderDesc, body);
@@ -44,7 +44,7 @@ export function initWorld(RAPIER, testbed) {
 
     // A very fast rigid-body with CCD enabled.
     // Create dynamic cube.
-    bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+    bodyDesc = RAPIER.RigidBodyDesc.dynamic()
         .setTranslation(-20.0, shiftY + 2.0, 0.0)
         .setLinvel(1000.0, 0.0, 0.0)
         .setCcdEnabled(true);

--- a/testbed3d/src/demos/collisionGroups.js
+++ b/testbed3d/src/demos/collisionGroups.js
@@ -3,7 +3,7 @@ export function initWorld(RAPIER, testbed) {
     let world = new RAPIER.World(gravity);
 
     // Create Ground.
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let groundBody = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(5.0, 0.1, 5.0);
     world.createCollider(colliderDesc, groundBody);
@@ -43,8 +43,9 @@ export function initWorld(RAPIER, testbed) {
 
                 // Alternate between the green and blue groups.
                 let group = k % 2 == 0 ? group1 : group2;
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y, z);
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
+
                 colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad)
                     .setCollisionGroups(group);
                 world.createCollider(colliderDesc, body);

--- a/testbed3d/src/demos/convexPolyhedron.js
+++ b/testbed3d/src/demos/convexPolyhedron.js
@@ -41,7 +41,7 @@ export function initWorld(RAPIER, testbed) {
     let world = new RAPIER.World(gravity);
 
     // Create Ground.
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 40.0, 4.0, 40.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
@@ -76,7 +76,7 @@ export function initWorld(RAPIER, testbed) {
                 vertices = new Float32Array(vertices);
 
                 // Build the rigid body.
-                bodyDesc = RAPIER.RigidBodyDesc.newDynamic().setTranslation(x, y, z);
+                bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y, z);
                 body = world.createRigidBody(bodyDesc);
                 colliderDesc = RAPIER.ColliderDesc.roundConvexHull(vertices, border_rad);
                 world.createCollider(colliderDesc, body);

--- a/testbed3d/src/demos/damping.js
+++ b/testbed3d/src/demos/damping.js
@@ -16,7 +16,7 @@ export function initWorld(RAPIER, testbed) {
         let y = Math.cos((i * subdiv * Math.PI * 2.0));
 
         // Build the rigid body.
-        let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+        let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
             .setTranslation(x, y, 0.0)
             .setLinvel(x * 10.0, y * 10.0, 0.0)
             .setAngvel(new RAPIER.Vector3(0.0, 0.0, 100.0))

--- a/testbed3d/src/demos/fountain.js
+++ b/testbed3d/src/demos/fountain.js
@@ -4,7 +4,7 @@ export function initWorld(RAPIER, testbed) {
     let removableBodies = new Array();
 
     // Create Ground.
-    let groundBodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let groundBodyDesc = RAPIER.RigidBodyDesc.fixed();
     let groundBody = world.createRigidBody(groundBodyDesc);
     let groundColliderDesc = RAPIER.ColliderDesc.cuboid(40.0, 0.1, 40.0);
     world.createCollider(groundColliderDesc, groundBody);
@@ -20,7 +20,7 @@ export function initWorld(RAPIER, testbed) {
             return;
         }
 
-        let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+        let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
             .setLinvel(0.0, 15.0, 0.0)
             .setTranslation(0.0, 10.0, 0.0);
         let colliderDesc;
@@ -52,7 +52,7 @@ export function initWorld(RAPIER, testbed) {
 
         // We reached the max number, delete the oldest rigid-body.
         if (removableBodies.length > 400) {
-            let rb = world.getRigidBody(removableBodies[0]);
+            let rb = removableBodies[0];
             world.removeRigidBody(rb);
             graphics.removeRigidBody(rb);
             removableBodies.shift();

--- a/testbed3d/src/demos/heightfield.js
+++ b/testbed3d/src/demos/heightfield.js
@@ -22,7 +22,7 @@ export function initWorld(RAPIER, testbed) {
     // Create Ground.
     let nsubdivs = 20;
     let scale = new RAPIER.Vector3(70.0, 4.0, 70.0);
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let heights = generateHeightfield(nsubdivs)
     let colliderDesc = RAPIER.ColliderDesc.heightfield(nsubdivs, nsubdivs, heights, scale);
@@ -47,7 +47,7 @@ export function initWorld(RAPIER, testbed) {
                 let z = k * shift + offset;
 
                 // Create dynamic cube.
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                     .setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc;

--- a/testbed3d/src/demos/joints.js
+++ b/testbed3d/src/demos/joints.js
@@ -18,7 +18,7 @@ function createPrismaticJoints(
 
     for (i = 0; i < num; ++i) {
         z = origin.z + (i + 1) * shift;
-        let rigidBodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+        let rigidBodyDesc = RAPIER.RigidBodyDesc.dynamic()
             .setTranslation(origin.x, origin.y, z);
         let currChild = world.createRigidBody(rigidBodyDesc);
         let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);
@@ -79,7 +79,7 @@ function createRevoluteJoints(
         let parents = [currParent, currParent, currParent, currParent];
 
         for (k = 0; k < 4; ++k) {
-            let rigidBodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+            let rigidBodyDesc = RAPIER.RigidBodyDesc.dynamic()
                 .setTranslation(positions[k].x, positions[k].y, positions[k].z);
             let rigidBody = world.createRigidBody(rigidBodyDesc);
             let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);

--- a/testbed3d/src/demos/keva.js
+++ b/testbed3d/src/demos/keva.js
@@ -28,7 +28,7 @@ function buildBlock(
             for (k = 0; k < numz; ++k) {
                 let z = (i % 2) == 0 ? dim.z * k * 2.0 : spacing * k * 2.0;
                 // Build the rigid body.
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                     .setTranslation(
                         x + dim.x + shift.x,
                         y + dim.y + shift.y,
@@ -47,7 +47,7 @@ function buildBlock(
     for (i = 0; i < blockWidth / (dim.x * 2.0); ++i) {
         for (j = 0; j < blockWidth / (dim.z * 2.0); ++j) {
             // Build the rigid body.
-            let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                 .setTranslation(
                     i * dim.x * 2.0 + dim.x + shift.x,
                     dim.y + shift.y + blockHeight,
@@ -68,7 +68,7 @@ export function initWorld(RAPIER, testbed) {
     // Create Ground.
     let groundSize = 50.0;
     let groundHeight = 0.1;
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic()
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed()
         .setTranslation(0.0, -groundHeight, 0.0);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(groundSize, groundHeight, groundSize);

--- a/testbed3d/src/demos/lockedRotations.js
+++ b/testbed3d/src/demos/lockedRotations.js
@@ -8,7 +8,7 @@ export function initWorld(RAPIER, testbed) {
     let ground_size = 1.7;
     let ground_height = 0.1;
 
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic()
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed()
         .setTranslation(0.0, -ground_height, 0.0);
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(ground_size, ground_height, ground_size);
@@ -17,7 +17,7 @@ export function initWorld(RAPIER, testbed) {
     /*
      * A rectangle that only rotates along the `x` axis.
      */
-    bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+    bodyDesc = RAPIER.RigidBodyDesc.dynamic()
         .setTranslation(0.0, 3.0, 0.0)
         .lockTranslations()
         .restrictRotations(true, false, false);
@@ -29,7 +29,7 @@ export function initWorld(RAPIER, testbed) {
     /*
      * A cylinder that cannot rotate.
      */
-    bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+    bodyDesc = RAPIER.RigidBodyDesc.dynamic()
         .setTranslation(0.2, 5.0, 0.4)
         .lockRotations();
     body = world.createRigidBody(bodyDesc);

--- a/testbed3d/src/demos/platform.js
+++ b/testbed3d/src/demos/platform.js
@@ -41,7 +41,7 @@ export function initWorld(RAPIER, testbed) {
     let world = new RAPIER.World(gravity);
 
     // Create Ground.
-    let bodyDesc = RAPIER.RigidBodyDesc.newKinematicVelocityBased();
+    let bodyDesc = RAPIER.RigidBodyDesc.kinematicVelocityBased();
     let platformBody = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 70.0, 4.0, 70.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
@@ -75,7 +75,7 @@ export function initWorld(RAPIER, testbed) {
                 let z = k * shift + offset;
 
                 // Create dynamic cube.
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                     .setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc;

--- a/testbed3d/src/demos/pyramid.js
+++ b/testbed3d/src/demos/pyramid.js
@@ -3,7 +3,7 @@ export function initWorld(RAPIER, testbed) {
     let world = new RAPIER.World(gravity);
 
     // Create Ground.
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let colliderDesc = RAPIER.ColliderDesc.cuboid(30.0, 0.1, 30.0);
     world.createCollider(colliderDesc, body);
@@ -26,7 +26,7 @@ export function initWorld(RAPIER, testbed) {
                     - height * rad - center;
 
                 // Create dynamic cube.
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                     .setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad, rad);

--- a/testbed3d/src/demos/trimesh.js
+++ b/testbed3d/src/demos/trimesh.js
@@ -41,7 +41,7 @@ export function initWorld(RAPIER, testbed) {
     let world = new RAPIER.World(gravity);
 
     // Create Ground.
-    let bodyDesc = RAPIER.RigidBodyDesc.newStatic();
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
     let body = world.createRigidBody(bodyDesc);
     let trimesh = generateTriMesh(20, 70.0, 4.0, 70.0)
     let colliderDesc = RAPIER.ColliderDesc.trimesh(trimesh.vertices, trimesh.indices);
@@ -66,7 +66,7 @@ export function initWorld(RAPIER, testbed) {
                 let z = k * shift + offset;
 
                 // Create dynamic cube.
-                let bodyDesc = RAPIER.RigidBodyDesc.newDynamic()
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic()
                     .setTranslation(x, y, z);
                 let body = world.createRigidBody(bodyDesc);
                 let colliderDesc;


### PR DESCRIPTION
This PR replaces our uses of `Map` by an arena that keeps objects stored based on their handles. The iteration order is always determined by the hander’s indices determined by the Rust arenas. That way, we maintain determinism of iteration order after deserialization.