### PR TITLE
chore: install wasm-pack via npm

### DIFF
--- a/.github/workflows/rapier-js-ci-build.yml
+++ b/.github/workflows/rapier-js-ci-build.yml
@@ -2,9 +2,9 @@ name: rapier CI build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,7 +25,6 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install wasm-pack;
       - run: npm ci;
       - name: Build rapier2d
         run: cd rapier2d; ./build_all.sh;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,17 @@
         "rimraf": "3.0.2",
         "typedoc": "0.22.15",
         "typescript": "4.6.4",
-        "wasm-opt": "1.3.0"
+        "wasm-opt": "1.3.0",
+        "wasm-pack": "^0.10.2"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -16,6 +26,20 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/binary-install": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
+      "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.21.1",
+        "rimraf": "^3.0.2",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -41,6 +65,26 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -338,6 +382,19 @@
         "wasm-opt": "bin/wasm-opt.js"
       }
     },
+    "node_modules/wasm-pack": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.10.2.tgz",
+      "integrity": "sha512-Kuh8XAArQNVoikMUenjDs4+g6LpktgfXgqlp03G2dJKDBokA7Y8Cx6MDCnvREzNnmprk9IohHytwycVSemwe/w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "binary-install": "^0.1.0"
+      },
+      "bin": {
+        "wasm-pack": "run.js"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -368,11 +425,31 @@
     }
   },
   "dependencies": {
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "binary-install": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.1.tgz",
+      "integrity": "sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "rimraf": "^3.0.2",
+        "tar": "^6.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -394,6 +471,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "dev": true
     },
     "fs-minipass": {
@@ -616,6 +699,15 @@
       "requires": {
         "node-fetch": "^2.6.7",
         "tar": "^6.1.11"
+      }
+    },
+    "wasm-pack": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.10.2.tgz",
+      "integrity": "sha512-Kuh8XAArQNVoikMUenjDs4+g6LpktgfXgqlp03G2dJKDBokA7Y8Cx6MDCnvREzNnmprk9IohHytwycVSemwe/w==",
+      "dev": true,
+      "requires": {
+        "binary-install": "^0.1.0"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "rimraf": "3.0.2",
     "typedoc": "0.22.15",
     "typescript": "4.6.4",
-    "wasm-opt": "1.3.0"
+    "wasm-opt": "1.3.0",
+    "wasm-pack": "0.10.2"
   }
 }

--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -3,8 +3,8 @@
   "description": "Build scripts for compatibility package with inlined webassembly as base64.",
   "private": true,
   "scripts": {
-    "build-rust-2d": "cd ../rapier2d ; wasm-pack build --target web",
-    "build-rust-3d": "cd ../rapier3d ; wasm-pack build --target web",
+    "build-rust-2d": "cd ../rapier2d; wasm-pack build --target web",
+    "build-rust-3d": "cd ../rapier3d; wasm-pack build --target web",
     "build-rust": "npm run build-rust-2d && npm run build-rust-3d",
     "build-genjs": "sh ./gen_src.sh",
     "build-js": "rollup --config rollup.config.js",

--- a/rapier2d/build_rust.sh
+++ b/rapier2d/build_rust.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-wasm-pack build
+npx wasm-pack build
 sed -i.bak 's#dimforge_rapier#@dimforge/rapier#g' pkg/package.json
 sed -i.bak 's/"rapier_wasm2d_bg.wasm"/"*"/g' pkg/package.json
 rm pkg/*.bak

--- a/rapier3d/build_rust.sh
+++ b/rapier3d/build_rust.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-wasm-pack build
+npx wasm-pack build
 sed -i.bak 's#dimforge_rapier#@dimforge/rapier#g' pkg/package.json
 sed -i.bak 's/"rapier_wasm3d_bg.wasm"/"*"/g' pkg/package.json
 rm pkg/*.bak

--- a/testbed2d/package.json
+++ b/testbed2d/package.json
@@ -3,7 +3,7 @@
   "name": "rapier-testbed2d",
   "version": "0.1.0",
   "description": "JavaScript testbed for rapier.",
-  "license": "Apache v2",
+  "license": "Apache-2.0",
   "main": "dist/rapier-testbed2d.js",
   "scripts": {
     "build": "rimraf dist pkg && webpack -d",
@@ -13,7 +13,6 @@
   "dependencies": {
     "@dimforge/rapier2d": "^0.8.0",
     "dat.gui": "^0.7.7",
-    "matter-js": "^0.14.2",
     "md5": "^2.2.1",
     "pixi-viewport": "^4.13.2",
     "pixi.js": "^5.3.2",

--- a/testbed3d/package.json
+++ b/testbed3d/package.json
@@ -3,7 +3,7 @@
   "name": "rapier-testbed3d",
   "version": "0.1.0",
   "description": "JavaScript testbed for rapier.",
-  "license": "Apache v2",
+  "license": "Apache-2.0",
   "main": "dist/rapier-testbed3d.js",
   "scripts": {
     "build": "rimraf dist pkg && webpack -d",


### PR DESCRIPTION
Cuts away ~5 min from each CI run (`cargo install wasm-pack`). Functionality seems to be the same from my testing. 

This comes with the added benefit of an easier setup for new contributors, since they no longer need to manually install `wasm-pack`.