### PR TITLE
chore(ci): cache cargo

### DIFF
--- a/.github/workflows/rapier-js-ci-build.yml
+++ b/.github/workflows/rapier-js-ci-build.yml
@@ -25,6 +25,15 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: npm ci;
       - name: Build rapier2d
         run: cd rapier2d; ./build_all.sh;


### PR DESCRIPTION
Cache cargo binaries (?) to improve CI speed. You can compare the CI times on the commits to see the difference, when using the cache it's ~4 min faster