### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+### 0.8.0 (2022-03-31)
+#### Breaking changes
+- Most APIs that relied on rigid-body handles or collider handles have been modified to rely on `RigidBody`
+  or `Collider` objects instead. Handles are now only needed for events and hooks.
+- Rename STATIC to FIXED in the `ActiveCollisionTypes` flags.
+
+#### Added
+- Add a lines-based debug-renderer. See [#119](https://github.com/dimforge/rapier.js/pull/119) for examples of
+  integration of the debug-renderer with `THREE.js` and `PIXI.js`.
+- Each rigid-body, collider, impulse joint, and multibody joint now have a unique object instance. This instance
+  in only valid as long as the corresponding objects is inserted to the `World`.
+- Add a `wakeUp: bool` argument to the `World.createImpulseJoint` and `MultibodyJointSet::createMultibodyJoint` to
+  automatically wake-up the rigid-bodies attached to the inserted joint.
+- Add a `filter` callback to all the scene queries. Use this for filtering more fine-grained than collision groups.
+- Add `collider.shape` that represents the shape of a collider. This is a more convenient way of reading the collider’s 
+  shape properties. Modifying this shape will have no effect unless `collider.setShape` is called with the modified shape.
+- Add `Collider.containsPoint`, `.projectPoint`, `.intersectsRay`, `.castShape`, `.castCollider`, `.intersectsShape`, 
+  `.contactShape`, `.contactCollider`, `.castRay`, `.castRayAndGetNormal`.
+- Add `Shape.containsPoint`, `.projectPoint`, `.intersectsRay`, `.castShape`, `.intersectsShape`,
+  `.contactShape`, `.castRay`, `.castRayAndGetNormal`.
+- Add `World.projectPointAndGetFeature` which includes the feature Id the projected point lies on.
+- Add `RigidBodyDesc.sleeping` to initialize the rigid-body in a sleeping state.
+
 ### 0.8.0-alpha.2 (2022-03-20)
 The changelog hasn’t been updated yet.
 For an overview of the changes, refer to the changelog for the unreleased Rust version:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,8 +583,9 @@ dependencies = [
 
 [[package]]
 name = "rapier2d"
-version = "0.12.0"
-source = "git+https://github.com/dimforge/rapier?rev=fb1bfc7#fb1bfc762c89cd8c5bd745a82998c1662a1bf196"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f7f18a9281f4c4176754437a768e1b7124ce5729060c8743db670f7ebb3c43"
 dependencies = [
  "approx",
  "arrayvec",
@@ -605,8 +606,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.12.0"
-source = "git+https://github.com/dimforge/rapier?rev=fb1bfc7#fb1bfc762c89cd8c5bd745a82998c1662a1bf196"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de4a0087979f2c5c856bd7121b1cd295930cbbadf16b00f814f10cbf53bb02f"
 dependencies = [
  "approx",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ codegen-units = 1
 #simba = { path = "../simba" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-rapier2d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
-rapier3d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
+#rapier2d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
+#rapier3d = { git = "https://github.com/dimforge/rapier", rev = "fb1bfc7" }
 #parry2d = { git = "https://github.com/dimforge/parry" }
 #parry3d = { git = "https://github.com/dimforge/parry" }

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim2"]
 
 
 [dependencies]
-rapier2d = { version = "^0.12.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier2d = { version = "^0.13.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "0.2"
 js-sys = "0.3"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim3"]
 
 
 [dependencies]
-rapier3d = { version = "^0.12.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier3d = { version = "^0.13.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "0.2"
 js-sys = "0.3"

--- a/testbed2d/src/Testbed.js
+++ b/testbed2d/src/Testbed.js
@@ -118,6 +118,7 @@ export class Testbed {
         this.world.maxVelocityIterations = this.parameters.numVelocityIter;
         this.world.maxPositionIterations = this.parameters.numPositionIter;
         this.demoToken += 1;
+        this.stepId = 0;
         this.gui.resetTiming();
 
         world.forEachCollider(coll => {
@@ -155,12 +156,14 @@ export class Testbed {
 
     takeSnapshot() {
         this.snap = this.world.takeSnapshot();
+        this.snapStepId = this.stepId;
     }
 
     restoreSnapshot() {
         if (!!this.snap) {
             this.world.free();
             this.world = this.RAPIER.World.restoreSnapshot(this.snap);
+            this.stepId = this.snapStepId;
         }
     }
 

--- a/testbed3d/src/Testbed.js
+++ b/testbed3d/src/Testbed.js
@@ -119,6 +119,7 @@ export class Testbed {
         this.world.maxVelocityIterations = this.parameters.numVelocityIter;
         this.world.maxPositionIterations = this.parameters.numPositionIter;
         this.demoToken += 1;
+        this.stepId = 0;
         this.gui.resetTiming();
 
         world.forEachCollider(coll => {
@@ -143,7 +144,6 @@ export class Testbed {
 
         this.prevDemo = demo;
         this.graphics.reset();
-        this.stepId = 0;
 
         this.parameters.prevBackend = this.parameters.backend;
         this.parameters.builders.get(demo)(this.RAPIER, this);
@@ -156,12 +156,14 @@ export class Testbed {
 
     takeSnapshot() {
         this.snap = this.world.takeSnapshot();
+        this.snapStepId = this.stepId;
     }
 
     restoreSnapshot() {
         if (!!this.snap) {
             this.world.free();
             this.world = this.RAPIER.World.restoreSnapshot(this.snap);
+            this.stepId = this.snapStepId;
         }
     }
 


### PR DESCRIPTION
#### Breaking changes
- Most APIs that relied on rigid-body handles or collider handles have been modified to rely on `RigidBody`
  or `Collider` objects instead. Handles are now only needed for events and hooks.
- Rename STATIC to FIXED in the `ActiveCollisionTypes` flags.

#### Added
- Add a lines-based debug-renderer. See [#119](https://github.com/dimforge/rapier.js/pull/119) for examples of
  integration of the debug-renderer with `THREE.js` and `PIXI.js`.
- Each rigid-body, collider, impulse joint, and multibody joint now have a unique object instance. This instance
  in only valid as long as the corresponding objects is inserted to the `World`.
- Add a `wakeUp: bool` argument to the `World.createImpulseJoint` and `MultibodyJointSet::createMultibodyJoint` to
  automatically wake-up the rigid-bodies attached to the inserted joint.
- Add a `filter` callback to all the scene queries. Use this for filtering more fine-grained than collision groups.
- Add `collider.shape` that represents the shape of a collider. This is a more convenient way of reading the collider’s 
  shape properties. Modifying this shape will have no effect unless `collider.setShape` is called with the modified shape.
- Add `Collider.containsPoint`, `.projectPoint`, `.intersectsRay`, `.castShape`, `.castCollider`, `.intersectsShape`, 
  `.contactShape`, `.contactCollider`, `.castRay`, `.castRayAndGetNormal`.
- Add `Shape.containsPoint`, `.projectPoint`, `.intersectsRay`, `.castShape`, `.intersectsShape`,
  `.contactShape`, `.castRay`, `.castRayAndGetNormal`.
- Add `World.projectPointAndGetFeature` which includes the feature Id the projected point lies on.
- Add `RigidBodyDesc.sleeping` to initialize the rigid-body in a sleeping state.