### PR TITLE
chore(testbed): replace dat.gui with lil-gui

### DIFF
--- a/testbed2d/package-lock.json
+++ b/testbed2d/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@dimforge/rapier2d": "^0.8.0",
-                "dat.gui": "^0.7.7",
+                "lil-gui": "^0.16.1",
                 "md5": "^2.3.0",
                 "pixi-viewport": "^4.34.4",
                 "pixi.js": "^6.3.2",
@@ -18,7 +18,6 @@
                 "stats.js": "^0.17.0"
             },
             "devDependencies": {
-                "@types/dat.gui": "^0.7.7",
                 "@types/md5": "^2.3.2",
                 "@types/seedrandom": "^3.0.2",
                 "@types/stats.js": "^0.17.0",
@@ -546,12 +545,6 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/dat.gui": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
-            "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
-            "dev": true
         },
         "node_modules/@types/earcut": {
             "version": "2.1.1",
@@ -1446,11 +1439,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/dat.gui": {
-            "version": "0.7.9",
-            "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-            "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ=="
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -2454,6 +2442,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/lil-gui": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.16.1.tgz",
+            "integrity": "sha512-6wnnfBvQxJYRhdLyIA+w5b8utwbuVxNmtpTXElm36OSgHa8lyKp00Xz/4AEx3kvodT0AJYgbfadCFWAM0Q8DgQ=="
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -4619,12 +4612,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/dat.gui": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
-            "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
-            "dev": true
-        },
         "@types/earcut": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
@@ -5359,11 +5346,6 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
-        },
-        "dat.gui": {
-            "version": "0.7.9",
-            "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-            "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ=="
         },
         "debug": {
             "version": "2.6.9",
@@ -6139,6 +6121,11 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
+        },
+        "lil-gui": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.16.1.tgz",
+            "integrity": "sha512-6wnnfBvQxJYRhdLyIA+w5b8utwbuVxNmtpTXElm36OSgHa8lyKp00Xz/4AEx3kvodT0AJYgbfadCFWAM0Q8DgQ=="
         },
         "loader-runner": {
             "version": "4.3.0",

--- a/testbed2d/package.json
+++ b/testbed2d/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@dimforge/rapier2d": "^0.8.0",
-        "dat.gui": "^0.7.7",
+        "lil-gui": "^0.16.1",
         "md5": "^2.3.0",
         "pixi-viewport": "^4.34.4",
         "pixi.js": "^6.3.2",
@@ -20,7 +20,6 @@
         "stats.js": "^0.17.0"
     },
     "devDependencies": {
-        "@types/dat.gui": "^0.7.7",
         "@types/md5": "^2.3.2",
         "@types/seedrandom": "^3.0.2",
         "@types/stats.js": "^0.17.0",

--- a/testbed3d/package-lock.json
+++ b/testbed3d/package-lock.json
@@ -10,14 +10,13 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@dimforge/rapier3d": "^0.8.0",
-                "dat.gui": "^0.7.7",
+                "lil-gui": "^0.16.1",
                 "md5": "^2.3.0",
                 "seedrandom": "^3.0.5",
                 "stats.js": "^0.17.0",
                 "three": "^0.141.0"
             },
             "devDependencies": {
-                "@types/dat.gui": "^0.7.7",
                 "@types/md5": "^2.3.2",
                 "@types/seedrandom": "^3.0.2",
                 "@types/stats.js": "^0.17.0",
@@ -181,12 +180,6 @@
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/dat.gui": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
-            "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
-            "dev": true
         },
         "node_modules/@types/eslint": {
             "version": "8.4.2",
@@ -1098,11 +1091,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/dat.gui": {
-            "version": "0.7.9",
-            "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-            "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ=="
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -2076,6 +2064,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/lil-gui": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.16.1.tgz",
+            "integrity": "sha512-6wnnfBvQxJYRhdLyIA+w5b8utwbuVxNmtpTXElm36OSgHa8lyKp00Xz/4AEx3kvodT0AJYgbfadCFWAM0Q8DgQ=="
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -3937,12 +3930,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/dat.gui": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
-            "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -4694,11 +4681,6 @@
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
         },
-        "dat.gui": {
-            "version": "0.7.9",
-            "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
-            "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ=="
-        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5445,6 +5427,11 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
+        },
+        "lil-gui": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.16.1.tgz",
+            "integrity": "sha512-6wnnfBvQxJYRhdLyIA+w5b8utwbuVxNmtpTXElm36OSgHa8lyKp00Xz/4AEx3kvodT0AJYgbfadCFWAM0Q8DgQ=="
         },
         "loader-runner": {
             "version": "4.3.0",

--- a/testbed3d/package.json
+++ b/testbed3d/package.json
@@ -12,14 +12,13 @@
     },
     "dependencies": {
         "@dimforge/rapier3d": "^0.8.0",
-        "dat.gui": "^0.7.7",
+        "lil-gui": "^0.16.1",
         "md5": "^2.3.0",
         "seedrandom": "^3.0.5",
         "stats.js": "^0.17.0",
         "three": "^0.141.0"
     },
     "devDependencies": {
-        "@types/dat.gui": "^0.7.7",
         "@types/md5": "^2.3.2",
         "@types/seedrandom": "^3.0.2",
         "@types/stats.js": "^0.17.0",

--- a/testbed3d/src/Gui.ts
+++ b/testbed3d/src/Gui.ts
@@ -1,4 +1,4 @@
-import * as dat from "dat.gui";
+import GUI from "lil-gui";
 import * as Stats from "stats.js";
 import type {Testbed} from "./Testbed";
 
@@ -16,9 +16,7 @@ export class Gui {
     maxTimePanelValue: number;
     stepTimePanel1: Stats.Panel;
     stepTimePanel2: Stats.Panel;
-    gui: dat.GUI;
-    velIter: dat.GUIController;
-    posIter: dat.GUIController;
+    gui: GUI;
     debugText: HTMLDivElement;
 
     constructor(testbed: Testbed, simulationParameters: Testbed["parameters"]) {
@@ -44,46 +42,51 @@ export class Gui {
         var me = this;
 
         // For configuring simulation parameters.
-        this.gui = new dat.GUI({
-            name: "Rapier JS demos",
+        this.gui = new GUI({
+            title: "Rapier JS demos",
         });
         this.gui
             .add(simulationParameters, "backend", backends)
-            .onChange(function (backend) {
+            .onChange((backend: string) => {
                 testbed.switchToBackend(backend);
             });
         var currDemo = this.gui
             .add(simulationParameters, "demo", demos)
-            .onChange(function (demo) {
+            .onChange((demo: string) => {
                 testbed.switchToDemo(demo);
             });
-        this.velIter = this.gui
+        this.gui
             .add(simulationParameters, "numVelocityIter", 0, 20)
             .step(1)
             .listen();
-        this.posIter = this.gui
+        this.gui
             .add(simulationParameters, "numPositionIter", 0, 20)
             .step(1)
             .listen();
-        this.gui.add(simulationParameters, "debugInfos").listen();
+        this.gui
+            .add(simulationParameters, "debugInfos")
+            .listen()
+            .onChange((value: boolean) => {
+                me.debugText.style.visibility = value ? "visible" : "hidden";
+            });
         this.gui.add(simulationParameters, "debugRender").listen();
-        this.gui.add(simulationParameters, "running", true).listen();
-        this.gui.add(simulationParameters, "step").onChange(function () {
+        this.gui.add(simulationParameters, "running").listen();
+        this.gui.add(simulationParameters, "step");
+        simulationParameters.step = () => {
             simulationParameters.stepping = true;
-        });
-        this.gui
-            .add(simulationParameters, "takeSnapshot")
-            .onChange(function () {
-                testbed.takeSnapshot();
-            });
-        this.gui
-            .add(simulationParameters, "restoreSnapshot")
-            .onChange(function () {
-                testbed.restoreSnapshot();
-            });
-        this.gui.add(simulationParameters, "restart").onChange(function () {
+        };
+        this.gui.add(simulationParameters, "takeSnapshot");
+        simulationParameters.takeSnapshot = () => {
+            testbed.takeSnapshot();
+        };
+        this.gui.add(simulationParameters, "restoreSnapshot");
+        simulationParameters.restoreSnapshot = () => {
+            testbed.restoreSnapshot();
+        };
+        this.gui.add(simulationParameters, "restart");
+        simulationParameters.restart = () => {
             testbed.switchToDemo(currDemo.getValue());
-        });
+        };
 
         /*
          * Block of text for debug infos.
@@ -93,6 +96,7 @@ export class Gui {
         this.debugText.innerHTML = "";
         this.debugText.style.top = 50 + "px";
         this.debugText.style.visibility = "visible";
+        this.debugText.style.color = "#fff";
         document.body.appendChild(this.debugText);
     }
 


### PR DESCRIPTION
`lil-gui` is a modern and maintained alternative to `dat.gui`. E.g. ThreeJS have migrated all their examples to use it

https://github.com/georgealways/lil-gui

The `onChange` cb has been removed from fns, otherwise pretty much a straight replacement.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/8997319/171369054-42469fe1-b64d-49dc-a181-79b588bb8635.png">
