### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 0.8.1 (2022-04-06)
+
+Starting with this release, all the examples in `testbed2d` and `testbed3d` have been updated to `webpack 5`,
+and are written in Typescript. In addition, canary `0.0.0` releases will be generated automatically after each merge
+to the `master` branch.
+
+#### Fixed
+
+-   Fix bug causing `World.intersectionPair` to always return `false`.
+
 ### 0.8.0 (2022-03-31)
 
 #### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bincode",
  "crossbeam-channel 0.4.4",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bincode",
  "crossbeam-channel 0.4.4",

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier2d" # Can't be named rapier2d which conflicts with the dependency.
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier2d/index.html"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier3d" # Can't be named rapier3d which conflicts with the dependency.
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier2d/index.html"


### PR DESCRIPTION
Starting with this release, all the examples in `testbed2d` and `testbed3d` have been updated to `webpack 5`, and are written in Typescript. In addition, canary `0.0.0` releases will be generated automatically after each merge to the `master` branch.

#### Fixed

-   Fix bug causing `World.intersectionPair` to always return `false`.