### PR TITLE
chore(ci): cancel previous runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,11 @@ jobs:
     check-fmt:
         runs-on: ubuntu-latest
         steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.9.1
+              with:
+                  all_but_latest: true
+                  access_token: ${{ github.token }}
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
@@ -30,6 +35,11 @@ jobs:
         env:
             RUSTFLAGS: -D warnings
         steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.9.1
+              with:
+                  all_but_latest: true
+                  access_token: ${{ github.token }}
             - uses: actions/checkout@v3
             - uses: actions/cache@v3
               with:
@@ -67,6 +77,11 @@ jobs:
         needs: build
         if: github.ref == 'refs/heads/master'
         steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.9.1
+              with:
+                  all_but_latest: true
+                  access_token: ${{ github.token }}
             - uses: actions/checkout@v3
             - uses: actions/download-artifact@v3
               with:


### PR DESCRIPTION
Cancel previous CI run if new run is triggered. E.g. when merging a PR with multiple commits or merging multiple PRs quickly 

https://github.com/styfle/cancel-workflow-action

~You might have to add the github token as a secret, when trying in this branch there is an error `Error while canceling workflow_id 27187465: Resource not accessible by integration`~

nvm looks like the action doesn't work on forks but should be fine on master (which is the most important anyway)