### PR TITLE
Feature/add extra joint methods

### DIFF
--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -149,6 +149,18 @@ export class ImpulseJoint {
     public anchor2(): Vector {
         return VectorOps.fromRaw(this.rawSet.jointAnchor2(this.handle));
     }
+
+    public setAnchor1(newPos: Vector) {
+        const rawPoint = VectorOps.intoRaw(newPos);
+        this.rawSet.setJointAnchor1(this.handle, rawPoint);
+        rawPoint.free();
+    }
+
+    public setAnchor2(newPos: Vector) {
+        const rawPoint = VectorOps.intoRaw(newPos);
+        this.rawSet.setJointAnchor2(this.handle, rawPoint);
+        rawPoint.free();
+    }
 }
 
 export class UnitImpulseJoint extends ImpulseJoint {
@@ -176,6 +188,10 @@ export class UnitImpulseJoint extends ImpulseJoint {
      */
     public limitsMax(): number {
         return this.rawSet.jointLimitsMax(this.handle, this.rawAxis());
+    }
+
+    public setJointLimits(min: number, max: number) {
+        this.rawSet.setJointLimits(this.handle, this.rawAxis(), min, max);
     }
 
     public configureMotorModel(model: MotorModel) {

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -47,6 +47,28 @@ impl RawImpulseJointSet {
         self.map(handle, |j| j.data.local_frame2.translation.vector.into())
     }
 
+    /// Sets the position of the first local anchor
+    pub fn setJointAnchor1(
+        &mut self,
+        handle: FlatHandle,
+        newPos: &RawVector,
+    ) {
+        self.map_mut(handle, |j| {
+            j.data.set_local_anchor1(newPos.0.into());
+        });
+    }
+
+    /// Sets the position of the second local anchor
+    pub fn setJointAnchor2(
+        &mut self,
+        handle: FlatHandle,
+        newPos: &RawVector,
+    ) {
+        self.map_mut(handle, |j| {
+            j.data.set_local_anchor2(newPos.0.into());
+        })
+    }
+
     /// Are the limits for this joint enabled?
     pub fn jointLimitsEnabled(&self, handle: FlatHandle, axis: RawJointAxis) -> bool {
         self.map(handle, |j| {
@@ -59,9 +81,22 @@ impl RawImpulseJointSet {
         self.map(handle, |j| j.data.limits[axis as usize].min)
     }
 
+
     /// If this is a prismatic joint, returns its upper limit.
     pub fn jointLimitsMax(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].max)
+    }
+
+     pub fn setJointLimits(
+        &mut self,
+        handle: FlatHandle,
+        axis: RawJointAxis,
+        min: f32,
+        max: f32,
+    ) {
+        self.map_mut(handle, |j| {
+            j.data.set_limits(JointAxis::from(axis).into(), [min, max]);
+        });
     }
 
     pub fn jointConfigureMotorModel(

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -81,12 +81,12 @@ impl RawImpulseJointSet {
         self.map(handle, |j| j.data.limits[axis as usize].min)
     }
 
-
     /// If this is a prismatic joint, returns its upper limit.
     pub fn jointLimitsMax(&self, handle: FlatHandle, axis: RawJointAxis) -> f32 {
         self.map(handle, |j| j.data.limits[axis as usize].max)
     }
 
+    /// Enables and sets the joint limits
      pub fn setJointLimits(
         &mut self,
         handle: FlatHandle,


### PR DESCRIPTION
Added a few joint method that exist within Rapier, but are not yet exposed within Rapier.js. Specifically:

- Setting the joint's anchor points
- Setting a joint's limits
