### PR TITLE
Automatically enable a joint motor when configuring it.

### DIFF
--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -175,10 +175,8 @@ impl RawImpulseJointSet {
         damping: f32,
     ) {
         self.map_mut(handle, |j| {
-            j.data.motors[axis as usize].target_pos = targetPos;
-            j.data.motors[axis as usize].target_vel = targetVel;
-            j.data.motors[axis as usize].stiffness = stiffness;
-            j.data.motors[axis as usize].damping = damping;
+            j.data
+                .set_motor(axis.into(), targetPos, targetVel, stiffness, damping);
         })
     }
 }


### PR DESCRIPTION
Motor configuration set the motor’s properties but didn’t actually set the motor as enabled, so it didn’t have any visible effect.
Fix #150 