### PR TITLE
Added checks to init() in rapier3d-compat module to catch multiple calls

### DIFF
--- a/rapier-compat/src2d/init.ts
+++ b/rapier-compat/src2d/init.ts
@@ -4,9 +4,36 @@ import wasmInit from "../pkg2d/rapier_wasm2d";
 import base64 from "base64-js";
 
 /**
+ * Flag to check if RAPIER has already been initialized
+ * or is currently being initialized.
+ */
+let initialized = false;
+
+/**
+ * If init has already been called before but initialization
+ * is not done yet, the unresolved promise is returned.
+ */
+let initPromise: ReturnType<typeof wasmInit> | undefined = undefined;
+
+/**
  * Initializes RAPIER.
  * Has to be called and awaited before using any library methods.
  */
 export async function init() {
-    await wasmInit(base64.toByteArray(wasmBase64 as unknown as string).buffer);
+    // return if RAPIER has been initialized
+    if (initialized) return;
+
+    // return the unresolve promise if RAPIER is currently initializing
+    if (initPromise) return initPromise;
+
+    // init and assign promise
+    initPromise = wasmInit(
+        base64.toByteArray(wasmBase64 as unknown as string).buffer,
+    );
+
+    // await initialization
+    await initPromise;
+
+    // set initialized flag
+    initialized = true;
 }

--- a/rapier-compat/src3d/init.ts
+++ b/rapier-compat/src3d/init.ts
@@ -4,9 +4,36 @@ import wasmInit from "../pkg3d/rapier_wasm3d";
 import base64 from "base64-js";
 
 /**
+ * Flag to check if RAPIER has already been initialized
+ * or is currently being initialized.
+ */
+let initialized = false;
+
+/**
+ * If init has already been called before but initialization
+ * is not done yet, the unresolved promise is returned.
+ */
+let initPromise: ReturnType<typeof wasmInit> | undefined = undefined;
+
+/**
  * Initializes RAPIER.
  * Has to be called and awaited before using any library methods.
  */
 export async function init() {
-    await wasmInit(base64.toByteArray(wasmBase64 as unknown as string).buffer);
+    // return if RAPIER has been initialized
+    if (initialized) return;
+
+    // return the unresolve promise if RAPIER is currently initializing
+    if (initPromise) return initPromise;
+
+    // init and assign promise
+    initPromise = wasmInit(
+        base64.toByteArray(wasmBase64 as unknown as string).buffer,
+    );
+
+    // await initialization
+    await initPromise;
+
+    // set initialized flag
+    initialized = true;
 }


### PR DESCRIPTION
As calling `RAPIER.init()` multiple times results in overlapping pointers, weird results and random errors but sometimes also stable situations, it's rather hard to debug and classify.
This PR makes multiple calls to `RAPIER.init()` result in a single Promise being resolved.