### PR TITLE
Update to rapier 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee29895c34e7dae094c8ea355af4f6fb3f3ab6b76ea037b49bc51bf5972d2464"
+checksum = "f2451e4bf2c6ba705bf584f94bb51772e22977e37c82575ce2445dd797eb35a9"
 dependencies = [
  "approx",
  "arrayvec",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2420ecc938f3acf004ca7f5059aca5145324a88525879745e18ba6ea785d793"
+checksum = "ee763b47e68f62d578bcfc3f83cf75d9d970aed5df20b6d90287ca9b3195155d"
 dependencies = [
  "approx",
  "arrayvec",
@@ -542,8 +542,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rapier2d"
-version = "0.15.0"
-source = "git+https://github.com/dimforge/rapier?rev=9febe341fcf97a1b42cdb293b825e017821b86ca#9febe341fcf97a1b42cdb293b825e017821b86ca"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12435d8c8ea7eee77be71f90e87fea038e9630baf89008e4602f68fe39fcac06"
 dependencies = [
  "approx",
  "arrayvec",
@@ -564,8 +565,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.15.0"
-source = "git+https://github.com/dimforge/rapier?rev=9febe341fcf97a1b42cdb293b825e017821b86ca#9febe341fcf97a1b42cdb293b825e017821b86ca"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfab9e1384b38fccb76f2c4d799b94e8214fa1913e657e4645efbce5ba88bd02"
 dependencies = [
  "approx",
  "arrayvec",
@@ -658,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48e45e5961033db030b56ad67aef22e9c908c493a6e8348c0a0f6b93433cd77"
+checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
 dependencies = [
  "approx",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ codegen-units = 1
 #simba = { path = "../simba" }
 
 #nalgebra = { git = "https://github.com/dimforge/nalgebra", branch = "dev" }
-rapier2d = { git = "https://github.com/dimforge/rapier", rev = "d60177774d06ea7df09c83674d5dea74241f7823" }
-rapier3d = { git = "https://github.com/dimforge/rapier", rev = "d60177774d06ea7df09c83674d5dea74241f7823" }
+#rapier2d = { git = "https://github.com/dimforge/rapier", rev = "d60177774d06ea7df09c83674d5dea74241f7823" }
+#rapier3d = { git = "https://github.com/dimforge/rapier", rev = "d60177774d06ea7df09c83674d5dea74241f7823" }
 #parry2d = { git = "https://github.com/dimforge/parry" }
 #parry3d = { git = "https://github.com/dimforge/parry" }

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim2"]
 
 
 [dependencies]
-rapier2d = { version = "^0.15.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier2d = { version = "^0.16.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim3"]
 
 
 [dependencies]
-rapier3d = { version = "^0.15.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier3d = { version = "^0.16.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -135,11 +135,11 @@ impl RawContactManifold {
     }
 
     pub fn contact_fid1(&self, i: usize) -> u32 {
-        unsafe { (*self.0).points.get(i).map(|c| c.fid1).unwrap_or(0) }
+        unsafe { (*self.0).points.get(i).map(|c| c.fid1.0).unwrap_or(0) }
     }
 
     pub fn contact_fid2(&self, i: usize) -> u32 {
-        unsafe { (*self.0).points.get(i).map(|c| c.fid2).unwrap_or(0) }
+        unsafe { (*self.0).points.get(i).map(|c| c.fid2.0).unwrap_or(0) }
     }
 
     pub fn contact_impulse(&self, i: usize) -> Real {

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -5,7 +5,7 @@ use na::DMatrix;
 #[cfg(feature = "dim2")]
 use na::DVector;
 use na::Unit;
-use rapier::geometry::{Shape, SharedShape};
+use rapier::geometry::{Shape, SharedShape, TriMeshFlags};
 use rapier::math::{Isometry, Point, Real, Vector, DIM};
 use rapier::parry::query;
 use rapier::parry::query::Ray;
@@ -292,7 +292,16 @@ impl RawShape {
     pub fn trimesh(vertices: Vec<f32>, indices: Vec<u32>) -> Self {
         let vertices = vertices.chunks(DIM).map(|v| Point::from_slice(v)).collect();
         let indices = indices.chunks(3).map(|v| [v[0], v[1], v[2]]).collect();
-        Self(SharedShape::trimesh(vertices, indices))
+        // NOTE: for the JS bindings, let’s just assume that the triangle mesh isn’t necessarily
+        // clean. We could provide more flexibility by allowing other flags to be given, but
+        // the API surface of the JS trimesh doesn’t really allow to benefit from other flags.
+        // So, let’s just keep MERGE_DUPLICATE_VERTICES which is useful to avoid internal edge
+        // problems.
+        Self(SharedShape::trimesh_with_flags(
+            vertices,
+            indices,
+            TriMeshFlags::MERGE_DUPLICATE_VERTICES,
+        ))
     }
 
     #[cfg(feature = "dim2")]

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -5,7 +5,7 @@ use crate::geometry::{
 };
 use crate::math::{RawRotation, RawVector};
 use crate::utils::{self, FlatHandle};
-use rapier::geometry::{ColliderHandle, Ray, AABB};
+use rapier::geometry::{Aabb, ColliderHandle, Ray};
 use rapier::math::{Isometry, Point};
 use rapier::pipeline::{QueryFilter, QueryFilterFlags, QueryPipeline};
 use rapier::prelude::FeatureId;
@@ -393,7 +393,7 @@ impl RawQueryPipeline {
         };
 
         let center = Point::from(aabbCenter.0);
-        let aabb = AABB::new(center - aabbHalfExtents.0, center + aabbHalfExtents.0);
+        let aabb = Aabb::new(center - aabbHalfExtents.0, center + aabbHalfExtents.0);
 
         self.0
             .colliders_with_aabb_intersecting_aabb(&aabb, rcallback)


### PR DESCRIPTION
This updates the internal Rust dependency to Rapier 0.16.0. This lets us benefit from the internal-edge problem fix for 3D triangle meshes and 3D heightfields.