### PR TITLE
fix: don't panic if calling .free() multiple times

### DIFF
--- a/src.ts/dynamics/ccd_solver.ts
+++ b/src.ts/dynamics/ccd_solver.ts
@@ -13,7 +13,9 @@ export class CCDSolver {
      * Release the WASM memory occupied by this narrow-phase.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/dynamics/impulse_joint_set.ts
+++ b/src.ts/dynamics/impulse_joint_set.ts
@@ -31,9 +31,14 @@ export class ImpulseJointSet {
      * Release the WASM memory occupied by this joint set.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
-        this.map.clear();
+
+        if (!!this.map) {
+            this.map.clear();
+        }
         this.map = undefined;
     }
 

--- a/src.ts/dynamics/integration_parameters.ts
+++ b/src.ts/dynamics/integration_parameters.ts
@@ -11,7 +11,9 @@ export class IntegrationParameters {
      * Free the WASM memory used by these integration parameters.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/dynamics/island_manager.ts
+++ b/src.ts/dynamics/island_manager.ts
@@ -14,7 +14,9 @@ export class IslandManager {
      * Release the WASM memory occupied by this narrow-phase.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -30,9 +30,14 @@ export class MultibodyJointSet {
      * Release the WASM memory occupied by this joint set.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
-        this.map.clear();
+
+        if (!!this.map) {
+            this.map.clear();
+        }
         this.map = undefined;
     }
 

--- a/src.ts/dynamics/rigid_body_set.ts
+++ b/src.ts/dynamics/rigid_body_set.ts
@@ -21,9 +21,14 @@ export class RigidBodySet {
      * Release the WASM memory occupied by this rigid-body set.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
-        this.map.clear();
+
+        if (!!this.map) {
+            this.map.clear();
+        }
         this.map = undefined;
     }
 

--- a/src.ts/geometry/broad_phase.ts
+++ b/src.ts/geometry/broad_phase.ts
@@ -13,7 +13,9 @@ export class BroadPhase {
      * Release the WASM memory occupied by this broad-phase.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/geometry/collider_set.ts
+++ b/src.ts/geometry/collider_set.ts
@@ -19,9 +19,14 @@ export class ColliderSet {
      * Release the WASM memory occupied by this collider set.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
-        this.map.clear();
+
+        if (!!this.map) {
+            this.map.clear();
+        }
         this.map = undefined;
     }
 

--- a/src.ts/geometry/narrow_phase.ts
+++ b/src.ts/geometry/narrow_phase.ts
@@ -16,7 +16,9 @@ export class NarrowPhase {
      * Release the WASM memory occupied by this narrow-phase.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 
@@ -101,7 +103,9 @@ export class TempContactManifold {
     raw: RawContactManifold;
 
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/pipeline/debug_render_pipeline.ts
+++ b/src.ts/pipeline/debug_render_pipeline.ts
@@ -48,7 +48,9 @@ export class DebugRenderPipeline {
      * Release the WASM memory occupied by this serialization pipeline.
      */
     free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
         this.vertices = undefined;
         this.colors = undefined;

--- a/src.ts/pipeline/event_queue.ts
+++ b/src.ts/pipeline/event_queue.ts
@@ -28,7 +28,9 @@ export class TempContactForceEvent {
     raw: RawContactForceEvent;
 
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 
@@ -105,7 +107,9 @@ export class EventQueue {
      * Release the WASM memory occupied by this event-queue.
      */
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/pipeline/physics_pipeline.ts
+++ b/src.ts/pipeline/physics_pipeline.ts
@@ -22,7 +22,9 @@ export class PhysicsPipeline {
     raw: RawPhysicsPipeline;
 
     public free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/pipeline/query_pipeline.ts
+++ b/src.ts/pipeline/query_pipeline.ts
@@ -69,7 +69,9 @@ export class QueryPipeline {
      * Release the WASM memory occupied by this query pipeline.
      */
     free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 

--- a/src.ts/pipeline/serialization_pipeline.ts
+++ b/src.ts/pipeline/serialization_pipeline.ts
@@ -23,7 +23,9 @@ export class SerializationPipeline {
      * Release the WASM memory occupied by this serialization pipeline.
      */
     free() {
-        this.raw.free();
+        if (!!this.raw) {
+            this.raw.free();
+        }
         this.raw = undefined;
     }
 


### PR DESCRIPTION
I sporadically get a `TypeError: this.raw is undefined` error from EventQueue, this could be a bug in my code where I call `.free()` to often. However I think the expected behavior is not to crash when doing so