### PR TITLE
Expose rigid body mass properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -1,6 +1,9 @@
 import {RawRigidBodySet} from "../raw";
 import {Rotation, RotationOps, Vector, VectorOps} from "../math";
-import {Collider, ColliderHandle, ColliderSet} from "../geometry";
+// #if DIM3
+import {SdpMatrix3, SdpMatrix3Ops} from "../math";
+// #endif
+import {Collider, ColliderSet} from "../geometry";
 
 /**
  * The integer identifier of a collider added to a `ColliderSet`.
@@ -484,6 +487,133 @@ export class RigidBody {
     public mass(): number {
         return this.rawSet.rbMass(this.handle);
     }
+
+    /**
+     * The inverse mass taking into account translation locking.
+     */
+    public effectiveInvMass(): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbEffectiveInvMass(this.handle));
+    }
+
+    /**
+     * The inverse of the mass of a rigid-body.
+     *
+     * If this is zero, the rigid-body is assumed to have infinite mass.
+     */
+    public invMass(): number {
+        return this.rawSet.rbInvMass(this.handle);
+    }
+
+    /**
+     * The center of mass of a rigid-body expressed in its local-space.
+     */
+    public localCom(): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbLocalCom(this.handle));
+    }
+
+    /**
+     * The world-space center of mass of the rigid-body.
+     */
+    public worldCom(): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbWorldCom(this.handle));
+    }
+
+    // #if DIM2
+    /**
+     * The inverse of the principal angular inertia of the rigid-body.
+     *
+     * Components set to zero are assumed to be infinite along the corresponding principal axis.
+     */
+    public invPrincipalInertiaSqrt(): number {
+        return this.rawSet.rbInvPrincipalInertiaSqrt(this.handle);
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * The inverse of the principal angular inertia of the rigid-body.
+     *
+     * Components set to zero are assumed to be infinite along the corresponding principal axis.
+     */
+    public invPrincipalInertiaSqrt(): Vector {
+        return VectorOps.fromRaw(
+            this.rawSet.rbInvPrincipalInertiaSqrt(this.handle),
+        );
+    }
+    // #endif
+
+    // #if DIM2
+    /**
+     * The angular inertia along the principal inertia axes of the rigid-body.
+     */
+    public principalInertia(): number {
+        return this.rawSet.rbPrincipalInertia(this.handle);
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * The angular inertia along the principal inertia axes of the rigid-body.
+     */
+    public principalInertia(): Vector {
+        return VectorOps.fromRaw(this.rawSet.rbPrincipalInertia(this.handle));
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * The principal vectors of the local angular inertia tensor of the rigid-body.
+     */
+    public principalInertiaLocalFrame(): Rotation {
+        return RotationOps.fromRaw(
+            this.rawSet.rbPrincipalInertiaLocalFrame(this.handle),
+        );
+    }
+    // #endif
+
+    // #if DIM2
+    /**
+     * The square-root of the world-space inverse angular inertia tensor of the rigid-body,
+     * taking into account rotation locking.
+     */
+    public effectiveWorldInvInertiaSqrt(): number {
+        return this.rawSet.rbEffectiveWorldInvInertiaSqrt(this.handle);
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * The square-root of the world-space inverse angular inertia tensor of the rigid-body,
+     * taking into account rotation locking.
+     */
+    public effectiveWorldInvInertiaSqrt(): SdpMatrix3 {
+        return SdpMatrix3Ops.fromRaw(
+            this.rawSet.rbEffectiveWorldInvInertiaSqrt(this.handle),
+        );
+    }
+    // #endif
+
+    // #if DIM2
+    /**
+     * The effective world-space angular inertia (that takes the potential rotation locking into account) of
+     * this rigid-body.
+     */
+    public effectiveAngularInertia(): number {
+        return this.rawSet.rbEffectiveAngularInertia(this.handle);
+    }
+    // #endif
+
+    // #if DIM3
+    /**
+     * The effective world-space angular inertia (that takes the potential rotation locking into account) of
+     * this rigid-body.
+     */
+    public effectiveAngularInertia(): SdpMatrix3 {
+        return SdpMatrix3Ops.fromRaw(
+            this.rawSet.rbEffectiveAngularInertia(this.handle),
+        );
+    }
+    // #endif
 
     /**
      * Put this rigid body to sleep.

--- a/src.ts/math.ts
+++ b/src.ts/math.ts
@@ -175,33 +175,75 @@ export class RotationOps {
     }
 }
 
+/**
+ * A 3D symmetric-positive-definite matrix.
+ */
 export class SdpMatrix3 {
     /**
-     * Row major list of the angular inertia SpdMatrix3 elements
+     * Row major list of the upper-triangular part of the symmetric matrix.
      */
     elements: Float32Array;
 
-    get m11(): number {
+    /**
+     * Matrix element at row 1, column 1.
+     */
+    public get m11(): number {
         return this.elements[0];
     }
 
-    get m12(): number {
+    /**
+     * Matrix element at row 1, column 2.
+     */
+    public get m12(): number {
         return this.elements[1];
     }
 
-    get m13(): number {
+    /**
+     * Matrix element at row 2, column 1.
+     */
+    public get m21(): number {
+        return this.m12;
+    }
+
+    /**
+     * Matrix element at row 1, column 3.
+     */
+    public get m13(): number {
         return this.elements[2];
     }
 
-    get m22(): number {
+    /**
+     * Matrix element at row 3, column 1.
+     */
+    public get m31(): number {
+        return this.m13;
+    }
+
+    /**
+     * Matrix element at row 2, column 2.
+     */
+    public get m22(): number {
         return this.elements[3];
     }
 
-    get m23(): number {
+    /**
+     * Matrix element at row 2, column 3.
+     */
+    public get m23(): number {
         return this.elements[4];
     }
 
-    get m33(): number {
+    /**
+     * Matrix element at row 3, column 2.
+     */
+    public get m32(): number {
+        return this.m23;
+    }
+
+    /**
+     * Matrix element at row 3, column 3.
+     */
+    public get m33(): number {
         return this.elements[5];
     }
 

--- a/src.ts/math.ts
+++ b/src.ts/math.ts
@@ -1,4 +1,7 @@
 import {RawVector, RawRotation} from "./raw";
+// #if DIM3
+import {RawSdpMatrix3} from "./raw";
+// #endif
 
 // #if DIM2
 export interface Vector {
@@ -169,6 +172,49 @@ export class RotationOps {
         out.y = input.y;
         out.z = input.z;
         out.w = input.w;
+    }
+}
+
+export class SdpMatrix3 {
+    /**
+     * Row major list of the angular inertia SpdMatrix3 elements
+     */
+    elements: Float32Array;
+
+    get m11(): number {
+        return this.elements[0];
+    }
+
+    get m12(): number {
+        return this.elements[1];
+    }
+
+    get m13(): number {
+        return this.elements[2];
+    }
+
+    get m22(): number {
+        return this.elements[3];
+    }
+
+    get m23(): number {
+        return this.elements[4];
+    }
+
+    get m33(): number {
+        return this.elements[5];
+    }
+
+    constructor(elements: Float32Array) {
+        this.elements = elements;
+    }
+}
+
+export class SdpMatrix3Ops {
+    public static fromRaw(raw: RawSdpMatrix3): SdpMatrix3 {
+        const sdpMatrix3 = new SdpMatrix3(raw.elements());
+        raw.free();
+        return sdpMatrix3;
     }
 }
 

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -1,5 +1,7 @@
 use crate::dynamics::{RawRigidBodySet, RawRigidBodyType};
 use crate::geometry::RawColliderSet;
+#[cfg(feature = "dim3")]
+use crate::math::RawSdpMatrix3;
 use crate::math::{RawRotation, RawVector};
 use crate::utils::{self, FlatHandle};
 use rapier::dynamics::MassProperties;
@@ -359,6 +361,120 @@ impl RawRigidBodySet {
     /// The mass of this rigid-body.
     pub fn rbMass(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |rb| rb.mass())
+    }
+
+    /// The inverse of the mass of a rigid-body.
+    ///
+    /// If this is zero, the rigid-body is assumed to have infinite mass.
+    pub fn rbInvMass(&mut self, handle: FlatHandle) -> f32 {
+        self.map_mut(handle, |rb| rb.mass_properties().local_mprops.inv_mass)
+    }
+
+    /// The inverse mass taking into account translation locking.
+    pub fn rbEffectiveInvMass(&mut self, handle: FlatHandle) -> RawVector {
+        self.map_mut(handle, |rb| rb.mass_properties().effective_inv_mass.into())
+    }
+
+    /// The center of mass of a rigid-body expressed in its local-space.
+    pub fn rbLocalCom(&mut self, handle: FlatHandle) -> RawVector {
+        self.map_mut(handle, |rb| {
+            rb.mass_properties().local_mprops.local_com.into()
+        })
+    }
+
+    /// The world-space center of mass of the rigid-body.
+    pub fn rbWorldCom(&mut self, handle: FlatHandle) -> RawVector {
+        self.map_mut(handle, |rb| rb.mass_properties().world_com.into())
+    }
+
+    /// The inverse of the principal angular inertia of the rigid-body.
+    ///
+    /// Components set to zero are assumed to be infinite along the corresponding principal axis.
+    #[cfg(feature = "dim2")]
+    pub fn rbInvPrincipalInertiaSqrt(&mut self, handle: FlatHandle) -> f32 {
+        self.map_mut(handle, |rb| {
+            rb.mass_properties()
+                .local_mprops
+                .inv_principal_inertia_sqrt
+                .into()
+        })
+    }
+
+    /// The inverse of the principal angular inertia of the rigid-body.
+    ///
+    /// Components set to zero are assumed to be infinite along the corresponding principal axis.
+    #[cfg(feature = "dim3")]
+    pub fn rbInvPrincipalInertiaSqrt(&mut self, handle: FlatHandle) -> RawVector {
+        self.map_mut(handle, |rb| {
+            rb.mass_properties()
+                .local_mprops
+                .inv_principal_inertia_sqrt
+                .into()
+        })
+    }
+
+    #[cfg(feature = "dim3")]
+    /// The principal vectors of the local angular inertia tensor of the rigid-body.
+    pub fn rbPrincipalInertiaLocalFrame(&mut self, handle: FlatHandle) -> RawRotation {
+        self.map_mut(handle, |rb| {
+            RawRotation::from(
+                rb.mass_properties()
+                    .local_mprops
+                    .principal_inertia_local_frame,
+            )
+        })
+    }
+
+    /// The angular inertia along the principal inertia axes of the rigid-body.
+    #[cfg(feature = "dim2")]
+    pub fn rbPrincipalInertia(&mut self, handle: FlatHandle) -> f32 {
+        self.map_mut(handle, |rb| {
+            rb.mass_properties().local_mprops.principal_inertia().into()
+        })
+    }
+
+    /// The angular inertia along the principal inertia axes of the rigid-body.
+    #[cfg(feature = "dim3")]
+    pub fn rbPrincipalInertia(&mut self, handle: FlatHandle) -> RawVector {
+        self.map_mut(handle, |rb| {
+            rb.mass_properties().local_mprops.principal_inertia().into()
+        })
+    }
+
+    /// The square-root of the world-space inverse angular inertia tensor of the rigid-body,
+    /// taking into account rotation locking.
+    #[cfg(feature = "dim2")]
+    pub fn rbEffectiveWorldInvInertiaSqrt(&self, handle: FlatHandle) -> f32 {
+        self.map(handle, |rb| {
+            rb.mass_properties().effective_world_inv_inertia_sqrt.into()
+        })
+    }
+
+    /// The square-root of the world-space inverse angular inertia tensor of the rigid-body,
+    /// taking into account rotation locking.
+    #[cfg(feature = "dim3")]
+    pub fn rbEffectiveWorldInvInertiaSqrt(&self, handle: FlatHandle) -> RawSdpMatrix3 {
+        self.map(handle, |rb| {
+            rb.mass_properties().effective_world_inv_inertia_sqrt.into()
+        })
+    }
+
+    /// The effective world-space angular inertia (that takes the potential rotation locking into account) of
+    /// this rigid-body.
+    #[cfg(feature = "dim2")]
+    pub fn rbEffectiveAngularInertia(&self, handle: FlatHandle) -> f32 {
+        self.map(handle, |rb| {
+            rb.mass_properties().effective_angular_inertia().into()
+        })
+    }
+
+    /// The effective world-space angular inertia (that takes the potential rotation locking into account) of
+    /// this rigid-body.
+    #[cfg(feature = "dim3")]
+    pub fn rbEffectiveAngularInertia(&self, handle: FlatHandle) -> RawSdpMatrix3 {
+        self.map(handle, |rb| {
+            rb.mass_properties().effective_angular_inertia().into()
+        })
     }
 
     /// Wakes this rigid-body up.

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -366,33 +366,33 @@ impl RawRigidBodySet {
     /// The inverse of the mass of a rigid-body.
     ///
     /// If this is zero, the rigid-body is assumed to have infinite mass.
-    pub fn rbInvMass(&mut self, handle: FlatHandle) -> f32 {
-        self.map_mut(handle, |rb| rb.mass_properties().local_mprops.inv_mass)
+    pub fn rbInvMass(&self, handle: FlatHandle) -> f32 {
+        self.map(handle, |rb| rb.mass_properties().local_mprops.inv_mass)
     }
 
     /// The inverse mass taking into account translation locking.
-    pub fn rbEffectiveInvMass(&mut self, handle: FlatHandle) -> RawVector {
-        self.map_mut(handle, |rb| rb.mass_properties().effective_inv_mass.into())
+    pub fn rbEffectiveInvMass(&self, handle: FlatHandle) -> RawVector {
+        self.map(handle, |rb| rb.mass_properties().effective_inv_mass.into())
     }
 
     /// The center of mass of a rigid-body expressed in its local-space.
-    pub fn rbLocalCom(&mut self, handle: FlatHandle) -> RawVector {
-        self.map_mut(handle, |rb| {
+    pub fn rbLocalCom(&self, handle: FlatHandle) -> RawVector {
+        self.map(handle, |rb| {
             rb.mass_properties().local_mprops.local_com.into()
         })
     }
 
     /// The world-space center of mass of the rigid-body.
-    pub fn rbWorldCom(&mut self, handle: FlatHandle) -> RawVector {
-        self.map_mut(handle, |rb| rb.mass_properties().world_com.into())
+    pub fn rbWorldCom(&self, handle: FlatHandle) -> RawVector {
+        self.map(handle, |rb| rb.mass_properties().world_com.into())
     }
 
     /// The inverse of the principal angular inertia of the rigid-body.
     ///
     /// Components set to zero are assumed to be infinite along the corresponding principal axis.
     #[cfg(feature = "dim2")]
-    pub fn rbInvPrincipalInertiaSqrt(&mut self, handle: FlatHandle) -> f32 {
-        self.map_mut(handle, |rb| {
+    pub fn rbInvPrincipalInertiaSqrt(&self, handle: FlatHandle) -> f32 {
+        self.map(handle, |rb| {
             rb.mass_properties()
                 .local_mprops
                 .inv_principal_inertia_sqrt
@@ -404,8 +404,8 @@ impl RawRigidBodySet {
     ///
     /// Components set to zero are assumed to be infinite along the corresponding principal axis.
     #[cfg(feature = "dim3")]
-    pub fn rbInvPrincipalInertiaSqrt(&mut self, handle: FlatHandle) -> RawVector {
-        self.map_mut(handle, |rb| {
+    pub fn rbInvPrincipalInertiaSqrt(&self, handle: FlatHandle) -> RawVector {
+        self.map(handle, |rb| {
             rb.mass_properties()
                 .local_mprops
                 .inv_principal_inertia_sqrt
@@ -415,8 +415,8 @@ impl RawRigidBodySet {
 
     #[cfg(feature = "dim3")]
     /// The principal vectors of the local angular inertia tensor of the rigid-body.
-    pub fn rbPrincipalInertiaLocalFrame(&mut self, handle: FlatHandle) -> RawRotation {
-        self.map_mut(handle, |rb| {
+    pub fn rbPrincipalInertiaLocalFrame(&self, handle: FlatHandle) -> RawRotation {
+        self.map(handle, |rb| {
             RawRotation::from(
                 rb.mass_properties()
                     .local_mprops
@@ -427,16 +427,16 @@ impl RawRigidBodySet {
 
     /// The angular inertia along the principal inertia axes of the rigid-body.
     #[cfg(feature = "dim2")]
-    pub fn rbPrincipalInertia(&mut self, handle: FlatHandle) -> f32 {
-        self.map_mut(handle, |rb| {
+    pub fn rbPrincipalInertia(&self, handle: FlatHandle) -> f32 {
+        self.map(handle, |rb| {
             rb.mass_properties().local_mprops.principal_inertia().into()
         })
     }
 
     /// The angular inertia along the principal inertia axes of the rigid-body.
     #[cfg(feature = "dim3")]
-    pub fn rbPrincipalInertia(&mut self, handle: FlatHandle) -> RawVector {
-        self.map_mut(handle, |rb| {
+    pub fn rbPrincipalInertia(&self, handle: FlatHandle) -> RawVector {
+        self.map(handle, |rb| {
             rb.mass_properties().local_mprops.principal_inertia().into()
         })
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,8 +1,14 @@
 //! Linear algebra primitives.
 
 #[cfg(feature = "dim3")]
+use js_sys::Float32Array;
+#[cfg(feature = "dim3")]
 use na::{Quaternion, Unit};
-use rapier::math::{Rotation, Vector};
+#[cfg(feature = "dim3")]
+use rapier::math::Real;
+use rapier::math::{Point, Rotation, Vector};
+#[cfg(feature = "dim3")]
+use rapier::parry::utils::SdpMatrix3;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -98,6 +104,20 @@ pub struct RawVector(pub(crate) Vector<f32>);
 impl From<Vector<f32>> for RawVector {
     fn from(v: Vector<f32>) -> Self {
         RawVector(v)
+    }
+}
+
+#[cfg(feature = "dim2")]
+impl From<Point<f32>> for RawVector {
+    fn from(v: Point<f32>) -> Self {
+        RawVector::new(v.x, v.y)
+    }
+}
+
+#[cfg(feature = "dim3")]
+impl From<Point<f32>> for RawVector {
+    fn from(v: Point<f32>) -> Self {
+        RawVector::new(v.x, v.y, v.x)
     }
 }
 
@@ -225,5 +245,30 @@ impl RawVector {
     #[cfg(feature = "dim3")]
     pub fn zyx(&self) -> Self {
         Self(self.0.zyx())
+    }
+}
+
+#[wasm_bindgen]
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+#[cfg(feature = "dim3")]
+pub struct RawSdpMatrix3(pub(crate) SdpMatrix3<Real>);
+
+#[cfg(feature = "dim3")]
+impl From<SdpMatrix3<Real>> for RawSdpMatrix3 {
+    fn from(v: SdpMatrix3<Real>) -> Self {
+        RawSdpMatrix3(v)
+    }
+}
+
+#[wasm_bindgen]
+#[cfg(feature = "dim3")]
+impl RawSdpMatrix3 {
+    /// Row major list of the angular inertia SpdMatrix3 elements
+    pub fn elements(&self) -> Float32Array {
+        let m = self.0;
+        let output = Float32Array::new_with_length(6);
+        output.copy_from(&[m.m11, m.m12, m.m13, m.m22, m.m23, m.m33]);
+        output
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -107,17 +107,9 @@ impl From<Vector<f32>> for RawVector {
     }
 }
 
-#[cfg(feature = "dim2")]
 impl From<Point<f32>> for RawVector {
-    fn from(v: Point<f32>) -> Self {
-        RawVector::new(v.x, v.y)
-    }
-}
-
-#[cfg(feature = "dim3")]
-impl From<Point<f32>> for RawVector {
-    fn from(v: Point<f32>) -> Self {
-        RawVector::new(v.x, v.y, v.x)
+    fn from(pt: Point<f32>) -> Self {
+        pt.coords.into()
     }
 }
 


### PR DESCRIPTION
### Why

- Expose rigid property mass properties necessary for creating custom controllers in user-land, e.g. vehicle controllers
- In particular, I have been porting the bullet/cannon RaycastVehicleController to rapier.js, which uses rigid body inertia properties to calculate impulses for braking
- Addresses https://github.com/dimforge/rapier.js/issues/194

### What
- Expose rigid body mass properties
  - `invMass`
  - `effectiveInvMass`
  - `localCom`
  - `worldCom`
  - `invPrincipalInertiaSqrt`
  - `principalInertia`
  - `principalInertiaLocalFrame` (DIM3 only)
  - `effectiveWorldInvInertiaSqrt`
  - `effectiveAngularInertia`