### PR TITLE
Add collider/rigidbody enable/disable + add query pipeline update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### Unreleased
+
+#### Added
+
+-   Add `World.propagateModifiedBodyPositionsToColliders` to propagate rigid-bodies position changes to their attached
+    colliders.
+-   Add `World.updateSceneQueries` to update the scene queries data structures without stepping the whole simulation.
+-   Add `RigidBody.isEnabled, RigidBody.setEnabled, RigidBodyDesc.setEnabled` to disable a rigid-body (and all its
+    attached colliders) without removing it from the physics world.
+-   Add `Collider.isEnabled, Collider.setEnabled, ColliderDesc.setEnabled` to disable a collider without removing it
+    from the physics world.
+-   Add shape-specific methods to modify a collider’s size: `Collider.setRadius, setHalfExtents, setRoundRadius, setHalfHeight`.
+
+#### Fixed
+
+-   Fix rigid-bodies automatically waking up at creation even if they were explicitly created sleeping.
+
 ### 0.10.0 (2022-11-06)
 
 #### Added
@@ -22,9 +39,6 @@
     before the filter-related arguments. Set this argument to `true` to get the same result as before. If this is set to
     `false` and the shape being cast starts it path already intersecting another shape, then a hit won’t be returned
     with that intersecting shape unless the casting movement would result in more penetrations.
-
-#### Modified
-
 -   Reduce rounding errors in 3D when setting the rotation of a rigid-body or collider.
 
 #### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,12 +64,6 @@ checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -80,22 +74,12 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.6",
+ "cfg-if",
+ "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.12",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -104,8 +88,8 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.12",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -114,9 +98,9 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.12",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -126,8 +110,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.12",
+ "cfg-if",
+ "crossbeam-utils",
  "memoffset",
  "scopeguard",
 ]
@@ -138,19 +122,8 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.12",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -159,7 +132,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -167,7 +140,7 @@ name = "dimforge_rapier2d"
 version = "0.10.0"
 dependencies = [
  "bincode",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "js-sys",
  "libm",
  "nalgebra",
@@ -183,7 +156,7 @@ name = "dimforge_rapier3d"
 version = "0.10.0"
 dependencies = [
  "bincode",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "js-sys",
  "nalgebra",
  "palette",
@@ -237,7 +210,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -253,12 +226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,7 +237,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -283,12 +250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e0a04ce089f9401aac565c740ed30c46291260f27d4911fdbaa6ca65fa3044"
+checksum = "f6515c882ebfddccaa73ead7320ca28036c4bc84c9bcca3cc0cbba8efe89223a"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -316,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -415,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2451e4bf2c6ba705bf584f94bb51772e22977e37c82575ce2445dd797eb35a9"
+checksum = "a2342b33d77a0393879b1b85eac2a30cc4b36d10b30e111f55a5e9280cf5eb87"
 dependencies = [
  "approx",
  "arrayvec",
@@ -438,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee763b47e68f62d578bcfc3f83cf75d9d970aed5df20b6d90287ca9b3195155d"
+checksum = "d2852a4cf8f65177e6f3755a725fdc0a433cca4fa6a97a07ae8c8abd7a4b52ea"
 dependencies = [
  "approx",
  "arrayvec",
@@ -542,9 +503,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rapier2d"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12435d8c8ea7eee77be71f90e87fea038e9630baf89008e4602f68fe39fcac06"
+checksum = "23262a297cfc3421bdd7588a2643e844c597872072eef60a87a3a1388a4d6fbd"
 dependencies = [
  "approx",
  "arrayvec",
@@ -565,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfab9e1384b38fccb76f2c4d799b94e8214fa1913e657e4645efbce5ba88bd02"
+checksum = "8aa1871dbbf25b2d91832c5f426827defc648d5340607870dc05471ab2748522"
 dependencies = [
  "approx",
  "arrayvec",
@@ -660,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
 dependencies = [
  "approx",
  "libm",
@@ -743,7 +704,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["dim2"]
 
 
 [dependencies]
-rapier2d = { version = "^0.16.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier2d = { version = "^0.17.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"
-nalgebra = "0.31"
+nalgebra = "0.32"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 palette = "0.6"
 libm = "0.2"
 

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -23,14 +23,14 @@ required-features = ["dim3"]
 
 
 [dependencies]
-rapier3d = { version = "^0.16.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier3d = { version = "^0.17.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"
-nalgebra = "0.31"
+nalgebra = "0.32"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 palette = "0.6"
 
 [package.metadata.wasm-pack.profile.release]

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -534,6 +534,22 @@ export class RigidBody {
     }
 
     /**
+     * Sets whether this rigid-body is enabled or not.
+     *
+     * @param enabled - Set to `false` to disable this rigid-body and all its attached colliders.
+     */
+    public setEnabled(enabled: boolean) {
+        this.rawSet.rbSetEnabled(this.handle, enabled);
+    }
+
+    /**
+     * Is this rigid-body enabled?
+     */
+    public isEnabled() {
+        return this.rawSet.rbIsEnabled(this.handle);
+    }
+
+    /**
      * The status of this rigid-body: static, dynamic, or kinematic.
      */
     public bodyType(): RigidBodyType {
@@ -543,8 +559,8 @@ export class RigidBody {
     /**
      * Set a new status for this rigid-body: static, dynamic, or kinematic.
      */
-    public setBodyType(type: RigidBodyType) {
-        return this.rawSet.rbSetBodyType(this.handle, type);
+    public setBodyType(type: RigidBodyType, wakeUp: boolean) {
+        return this.rawSet.rbSetBodyType(this.handle, type, wakeUp);
     }
 
     /**
@@ -864,6 +880,7 @@ export class RigidBody {
 }
 
 export class RigidBodyDesc {
+    enabled: boolean;
     translation: Vector;
     rotation: Rotation;
     gravityScale: number;
@@ -897,6 +914,7 @@ export class RigidBodyDesc {
     userData?: unknown;
 
     constructor(status: RigidBodyType) {
+        this.enabled = true;
         this.status = status;
         this.translation = VectorOps.zeros();
         this.rotation = RotationOps.identity();
@@ -995,6 +1013,15 @@ export class RigidBodyDesc {
 
     public setDominanceGroup(group: number): RigidBodyDesc {
         this.dominanceGroup = group;
+        return this;
+    }
+
+    /**
+     * Sets whether the created rigid-body will be enabled or disabled.
+     * @param enabled − If set to `false` the rigid-body will be disabled at creation.
+     */
+    public setEnabled(enabled: boolean): RigidBodyDesc {
+        this.enabled = enabled;
         return this;
     }
 

--- a/src.ts/dynamics/rigid_body_set.ts
+++ b/src.ts/dynamics/rigid_body_set.ts
@@ -75,6 +75,7 @@ export class RigidBodySet {
         // #endif
 
         let handle = this.raw.createRigidBody(
+            desc.enabled,
             rawTra,
             rawRot,
             desc.gravityScale,

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -197,6 +197,22 @@ export class Collider {
     }
 
     /**
+     * Sets whether this collider is enabled or not.
+     *
+     * @param enabled - Set to `false` to disable this collider (its parent rigid-body won’t be disabled automatically by this).
+     */
+    public setEnabled(enabled: boolean) {
+        this.colliderSet.raw.coSetEnabled(this.handle, enabled);
+    }
+
+    /**
+     * Is this collider enabled?
+     */
+    public isEnabled(): boolean {
+        return this.colliderSet.raw.coIsEnabled(this.handle);
+    }
+
+    /**
      * Sets the restitution coefficient of the collider to be created.
      *
      * @param restitution - The restitution coefficient in `[0, 1]`. A value of 0 (the default) means no bouncing behavior
@@ -1033,6 +1049,7 @@ export enum MassPropsMode {
 }
 
 export class ColliderDesc {
+    enabled: boolean;
     shape: Shape;
     massPropsMode: MassPropsMode;
     mass: number;
@@ -1518,6 +1535,15 @@ export class ColliderDesc {
      */
     public setSensor(sensor: boolean): ColliderDesc {
         this.isSensor = sensor;
+        return this;
+    }
+
+    /**
+     * Sets whether the created collider will be enabled or disabled.
+     * @param enabled − If set to `false` the collider will be disabled at creation.
+     */
+    public setEnabled(enabled: boolean): ColliderDesc {
+        this.enabled = enabled;
         return this;
     }
 

--- a/src.ts/geometry/collider_set.ts
+++ b/src.ts/geometry/collider_set.ts
@@ -95,6 +95,7 @@ export class ColliderSet {
         // #endif
 
         let handle = this.raw.createCollider(
+            desc.enabled,
             rawShape,
             rawTra,
             rawRot,

--- a/src.ts/pipeline/query_pipeline.ts
+++ b/src.ts/pipeline/query_pipeline.ts
@@ -84,12 +84,8 @@ export class QueryPipeline {
      * @param bodies - The set of rigid-bodies taking part in this pipeline.
      * @param colliders - The set of colliders taking part in this pipeline.
      */
-    public update(
-        islands: IslandManager,
-        bodies: RigidBodySet,
-        colliders: ColliderSet,
-    ) {
-        this.raw.update(islands.raw, bodies.raw, colliders.raw);
+    public update(bodies: RigidBodySet, colliders: ColliderSet) {
+        this.raw.update(bodies.raw, colliders.raw);
     }
 
     /**

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -247,7 +247,30 @@ export class World {
             eventQueue,
             hooks,
         );
-        this.queryPipeline.update(this.islands, this.bodies, this.colliders);
+        this.queryPipeline.update(this.bodies, this.colliders);
+    }
+
+    /**
+     * Update colliders positions after rigid-bodies moved.
+     *
+     * When a rigid-body moves, the positions of the colliders attached to it need to be updated. This update is
+     * generally automatically done at the beginning and the end of each simulation step with World.step.
+     * If the positions need to be updated without running a simulation step this method can be called manually.
+     */
+    public propagateModifiedBodyPositionsToColliders() {
+        this.bodies.raw.propagateModifiedBodyPositionsToColliders(
+            this.colliders.raw,
+        );
+    }
+
+    /**
+     * Ensure subsequent scene queries take into account the collider positions set before this method is called.
+     *
+     * This does not step the physics simulation forward.
+     */
+    public updateSceneQueries() {
+        this.propagateModifiedBodyPositionsToColliders();
+        this.queryPipeline.update(this.bodies, this.colliders);
     }
 
     /**

--- a/src/dynamics/rigid_body.rs
+++ b/src/dynamics/rigid_body.rs
@@ -397,8 +397,8 @@ impl RawRigidBodySet {
     }
 
     /// Set a new status for this rigid-body: fixed, dynamic, or kinematic.
-    pub fn rbSetBodyType(&mut self, handle: FlatHandle, status: RawRigidBodyType) {
-        self.map_mut(handle, |rb| rb.set_body_type(status.into()));
+    pub fn rbSetBodyType(&mut self, handle: FlatHandle, status: RawRigidBodyType, wake_up: bool) {
+        self.map_mut(handle, |rb| rb.set_body_type(status.into(), wake_up));
     }
 
     /// Is this rigid-body fixed?
@@ -432,6 +432,14 @@ impl RawRigidBodySet {
 
     pub fn rbSetAngularDamping(&mut self, handle: FlatHandle, factor: f32) {
         self.map_mut(handle, |rb| rb.set_angular_damping(factor));
+    }
+
+    pub fn rbSetEnabled(&mut self, handle: FlatHandle, enabled: bool) {
+        self.map_mut(handle, |rb| rb.set_enabled(enabled))
+    }
+
+    pub fn rbIsEnabled(&self, handle: FlatHandle) -> bool {
+        self.map(handle, |rb| rb.is_enabled())
     }
 
     pub fn rbGravityScale(&self, handle: FlatHandle) -> f32 {

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -223,6 +223,7 @@ impl RawRigidBodySet {
     }
 
     pub fn propagateModifiedBodyPositionsToColliders(&mut self, colliders: &mut RawColliderSet) {
-        self.0.propagate_modified_body_positions_to_colliders(&mut colliders.0);
+        self.0
+            .propagate_modified_body_positions_to_colliders(&mut colliders.0);
     }
 }

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -132,6 +132,7 @@ impl RawRigidBodySet {
     #[cfg(feature = "dim2")]
     pub fn createRigidBody(
         &mut self,
+        enabled: bool,
         translation: &RawVector,
         rotation: &RawRotation,
         gravityScale: f32,
@@ -154,6 +155,7 @@ impl RawRigidBodySet {
     ) -> FlatHandle {
         let pos = na::Isometry2::from_parts(translation.0.into(), rotation.0);
         let mut rigid_body = RigidBodyBuilder::new(rb_type.into())
+            .enabled(enabled)
             .position(pos)
             .gravity_scale(gravityScale)
             .enabled_translations(translationEnabledX, translationEnabledY)
@@ -218,5 +220,9 @@ impl RawRigidBodySet {
         for (handle, _) in self.0.iter() {
             let _ = f.call1(&this, &JsValue::from(utils::flat_handle(handle.0)));
         }
+    }
+
+    pub fn propagateModifiedBodyPositionsToColliders(&mut self, colliders: &mut RawColliderSet) {
+        self.0.propagate_modified_body_positions_to_colliders(&mut colliders.0);
     }
 }

--- a/src/dynamics/rigid_body_set.rs
+++ b/src/dynamics/rigid_body_set.rs
@@ -68,6 +68,7 @@ impl RawRigidBodySet {
     #[cfg(feature = "dim3")]
     pub fn createRigidBody(
         &mut self,
+        enabled: bool,
         translation: &RawVector,
         rotation: &RawRotation,
         gravityScale: f32,
@@ -95,6 +96,7 @@ impl RawRigidBodySet {
         let pos = na::Isometry3::from_parts(translation.0.into(), rotation.0);
 
         let mut rigid_body = RigidBodyBuilder::new(rb_type.into())
+            .enabled(enabled)
             .position(pos)
             .gravity_scale(gravityScale)
             .enabled_translations(

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -443,6 +443,14 @@ impl RawColliderSet {
         self.map(handle, |co| co.parent().map(|p| utils::flat_handle(p.0)))
     }
 
+    pub fn coSetEnabled(&mut self, handle: FlatHandle, enabled: bool) {
+        self.map_mut(handle, |co| co.set_enabled(enabled))
+    }
+
+    pub fn coIsEnabled(&self, handle: FlatHandle) -> bool {
+        self.map(handle, |co| co.is_enabled())
+    }
+
     /// The friction coefficient of this collider.
     pub fn coFriction(&self, handle: FlatHandle) -> f32 {
         self.map(handle, |co| co.material().friction)

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -42,6 +42,7 @@ impl RawColliderSet {
     // for the method arguments.
     pub fn do_create_collider(
         &mut self,
+        enabled: bool,
         shape: &RawShape,
         translation: &RawVector,
         rotation: &RawRotation,
@@ -69,6 +70,7 @@ impl RawColliderSet {
     ) -> Option<FlatHandle> {
         let pos = Isometry::from_parts(translation.0.into(), rotation.0);
         let mut builder = ColliderBuilder::new(shape.0.clone())
+            .enabled(enabled)
             .position(pos)
             .friction(friction)
             .restitution(restitution)
@@ -135,6 +137,7 @@ impl RawColliderSet {
     #[cfg(feature = "dim2")]
     pub fn createCollider(
         &mut self,
+        enabled: bool,
         shape: &RawShape,
         translation: &RawVector,
         rotation: &RawRotation,
@@ -159,6 +162,7 @@ impl RawColliderSet {
         bodies: &mut RawRigidBodySet,
     ) -> Option<FlatHandle> {
         self.do_create_collider(
+            enabled,
             shape,
             translation,
             rotation,
@@ -187,6 +191,7 @@ impl RawColliderSet {
     #[cfg(feature = "dim3")]
     pub fn createCollider(
         &mut self,
+        enabled: bool,
         shape: &RawShape,
         translation: &RawVector,
         rotation: &RawRotation,
@@ -212,6 +217,7 @@ impl RawColliderSet {
         bodies: &mut RawRigidBodySet,
     ) -> Option<FlatHandle> {
         self.do_create_collider(
+            enabled,
             shape,
             translation,
             rotation,

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -42,6 +42,7 @@ impl RawPhysicsPipeline {
             &mut joints.0,
             &mut articulations.0,
             &mut ccd_solver.0,
+            None,
             &(),
             &(),
         );
@@ -85,6 +86,7 @@ impl RawPhysicsPipeline {
             &mut joints.0,
             &mut articulations.0,
             &mut ccd_solver.0,
+            None,
             &hooks,
             &eventQueue.collector,
         );

--- a/src/pipeline/query_pipeline.rs
+++ b/src/pipeline/query_pipeline.rs
@@ -1,4 +1,4 @@
-use crate::dynamics::{RawIslandManager, RawRigidBodySet};
+use crate::dynamics::RawRigidBodySet;
 use crate::geometry::{
     RawColliderSet, RawPointColliderProjection, RawRayColliderIntersection, RawRayColliderToi,
     RawShape, RawShapeColliderTOI,
@@ -21,13 +21,8 @@ impl RawQueryPipeline {
         RawQueryPipeline(QueryPipeline::new())
     }
 
-    pub fn update(
-        &mut self,
-        islands: &RawIslandManager,
-        bodies: &RawRigidBodySet,
-        colliders: &RawColliderSet,
-    ) {
-        self.0.update(&islands.0, &bodies.0, &colliders.0);
+    pub fn update(&mut self, bodies: &RawRigidBodySet, colliders: &RawColliderSet) {
+        self.0.update(&bodies.0, &colliders.0);
     }
 
     pub fn castRay(


### PR DESCRIPTION
-   Switch to Rapier 0.17.
-   Add `World.propagateModifiedBodyPositionsToColliders` to propagate rigid-bodies position changes to their attached
    colliders.
-   Add `World.updateSceneQueries` to update the scene queries data structures without stepping the whole simulation.
-   Add `RigidBody.isEnabled, RigidBody.setEnabled, RigidBodyDesc.setEnabled` to disable a rigid-body (and all its
    attached colliders) without removing it from the physics world.
-   Add `Collider.isEnabled, Collider.setEnabled, ColliderDesc.setEnabled` to disable a collider without removing it
    from the physics world.
