### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 0.11.0 (2023-01-15)
 
 #### Added
 
@@ -10,6 +10,11 @@
 -   Add `Collider.isEnabled, Collider.setEnabled, ColliderDesc.setEnabled` to disable a collider without removing it
     from the physics world.
 -   Add shape-specific methods to modify a collider’s size: `Collider.setRadius, setHalfExtents, setRoundRadius, setHalfHeight`.
+
+#### Modified
+
+-   Add a boolean argument to `RigidBody.setBodyType` to indicate if the rigid-body should awaken after changing
+    its type.
 
 #### Fixed
 

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier2d" # Can't be named rapier2d which conflicts with the dependency.
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "2-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier2d/index.html"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_rapier3d" # Can't be named rapier3d which conflicts with the dependency.
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "3-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier2d/index.html"


### PR DESCRIPTION
-   Add `World.propagateModifiedBodyPositionsToColliders` to propagate rigid-bodies position changes to their attached
    colliders.
-   Add `World.updateSceneQueries` to update the scene queries data structures without stepping the whole simulation.
-   Add `RigidBody.isEnabled, RigidBody.setEnabled, RigidBodyDesc.setEnabled` to disable a rigid-body (and all its
    attached colliders) without removing it from the physics world.
-   Add `Collider.isEnabled, Collider.setEnabled, ColliderDesc.setEnabled` to disable a collider without removing it
    from the physics world.
-   Add shape-specific methods to modify a collider’s size: `Collider.setRadius, setHalfExtents, setRoundRadius, setHalfHeight`.

#### Modified

- Add a boolean argument to `RigidBody.setBodyType` to indicate if the rigid-body should awaken after changing
  its type.

#### Fixed

-   Fix rigid-bodies automatically waking up at creation even if they were explicitly created sleeping.