### PR TITLE
Fix collider initial enable status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -545,7 +545,7 @@ export class RigidBody {
     /**
      * Is this rigid-body enabled?
      */
-    public isEnabled() {
+    public isEnabled(): boolean {
         return this.rawSet.rbIsEnabled(this.handle);
     }
 

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -1083,6 +1083,7 @@ export class ColliderDesc {
      * @param shape - The shape of the collider being built.
      */
     constructor(shape: Shape) {
+        this.enabled = true;
         this.shape = shape;
         this.massPropsMode = MassPropsMode.Density;
         this.density = 1.0;


### PR DESCRIPTION
Not sure why I didn’t catch this yesterday. I probably mistakenly tested an older build.
Fix #205 