### PR TITLE
Uses Rapier 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### Unreleased
+
+#### Fixed
+
+-   Fix bug that made dynamic rigid-bodies behave like kinematic bodies after being disabled and then re-enabled.
+
+#### Added
+
+-   Add access to the mass-properties of a rigid-body: `RigidBody.effectiveInvMass`, `.invMass()`, `.localCom()`,
+    `.worldCom()`, `.invPrincipalInertiaSqrt()`, `.principalInertia()`, `.principalInertiaLocalFrame()`,
+    `.effectiveWorldInvInertiaSqrt()`, `.effectiveAngularInertia()`.
+
 ### 0.11.1 (2023-01-16)
 
 #### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,9 +503,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rapier2d"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23262a297cfc3421bdd7588a2643e844c597872072eef60a87a3a1388a4d6fbd"
+checksum = "dcd37fc7fad61534f35ce9cb198283cd7055c08cdc4a1565d0974a1fe74d5e59"
 dependencies = [
  "approx",
  "arrayvec",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa1871dbbf25b2d91832c5f426827defc648d5340607870dc05471ab2748522"
+checksum = "33c3a4adb69feadac44d74be058aaaec4502f9c193ec20c0e629b07387ee61a2"
 dependencies = [
  "approx",
  "arrayvec",

--- a/rapier2d/Cargo.toml
+++ b/rapier2d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim2"]
 
 
 [dependencies]
-rapier2d = { version = "^0.17.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier2d = { version = "^0.17.1", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"

--- a/rapier3d/Cargo.toml
+++ b/rapier3d/Cargo.toml
@@ -23,7 +23,7 @@ required-features = ["dim3"]
 
 
 [dependencies]
-rapier3d = { version = "^0.17.0", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
+rapier3d = { version = "^0.17.1", features = ["wasm-bindgen", "serde-serialize", "enhanced-determinism", "debug-render"] }
 ref-cast = "1"
 wasm-bindgen = "^0.2.82"
 js-sys = "0.3"


### PR DESCRIPTION
This should address #207. In some cases, a dynamic body that would be enabled and then re-enabled could start acting as kinematic bodies because their mass properties were not recomputed properly.