### PR TITLE
use yencode instead of base64

### DIFF
--- a/rapier-compat/package-lock.json
+++ b/rapier-compat/package-lock.json
@@ -6,18 +6,17 @@
         "": {
             "name": "build-rapier",
             "dependencies": {
-                "base64-js": "^1.5.1"
+                "simple-yenc": "^0.2.3"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^23.0.2",
                 "@rollup/plugin-node-resolve": "^15.0.1",
-                "@rollup/plugin-terser": "0.1.0",
+                "@rollup/plugin-terser": "^0.4.0",
                 "@rollup/plugin-typescript": "^9.0.2",
                 "@types/jest": "^29.2.1",
                 "jest": "^29.2.2",
                 "rimraf": "^3.0.2",
                 "rollup": "^3.2.5",
-                "rollup-plugin-base64": "^1.0.1",
                 "rollup-plugin-copy": "^3.4.0",
                 "rollup-plugin-filesize": "^9.1.2",
                 "ts-jest": "^29.0.3",
@@ -1233,11 +1232,13 @@
             }
         },
         "node_modules/@rollup/plugin-terser": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
-            "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+            "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
             "dev": true,
             "dependencies": {
+                "serialize-javascript": "^6.0.0",
+                "smob": "^0.0.6",
                 "terser": "^5.15.1"
             },
             "engines": {
@@ -1790,25 +1791,6 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -4906,6 +4888,15 @@
                 }
             ]
         },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "node_modules/react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -5111,60 +5102,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/rollup-plugin-base64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-base64/-/rollup-plugin-base64-1.0.1.tgz",
-            "integrity": "sha512-IbdX8fjuXO/Op3hYmRPjVo0VwcSenwsQDaDTFdoe+70B5ZGoLMtr96L2yhHXCfxv7HwZVvxZqLsuWj6VwzRt3g==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^3.1.0"
-            }
-        },
-        "node_modules/rollup-plugin-base64/node_modules/@rollup/pluginutils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-            "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "0.0.39",
-                "estree-walker": "^1.0.1",
-                "picomatch": "^2.2.2"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0"
-            }
-        },
-        "node_modules/rollup-plugin-base64/node_modules/@types/estree": {
-            "version": "0.0.39",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-            "dev": true
-        },
-        "node_modules/rollup-plugin-base64/node_modules/estree-walker": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-            "dev": true
-        },
-        "node_modules/rollup-plugin-base64/node_modules/rollup": {
-            "version": "2.79.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-            "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-            "dev": true,
-            "peer": true,
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
         "node_modules/rollup-plugin-copy": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
@@ -5244,6 +5181,15 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "dev": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "node_modules/set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5277,6 +5223,15 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
+        "node_modules/simple-yenc": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-0.2.3.tgz",
+            "integrity": "sha512-LGufdReGRgj0dXpqpF7j/MQ8SKu4pXAzpkHxQSDI0/GMOlmGY6oivl2hhsyMfAaOGYC6iqcxiDtBy+1MmM4JSA==",
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/eshaz"
+            }
+        },
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5301,6 +5256,12 @@
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
             }
+        },
+        "node_modules/smob": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+            "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+            "dev": true
         },
         "node_modules/socks": {
             "version": "2.6.2",
@@ -6894,11 +6855,13 @@
             }
         },
         "@rollup/plugin-terser": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.1.0.tgz",
-            "integrity": "sha512-N2KK+qUfHX2hBzVzM41UWGLrEmcjVC37spC8R3c9mt3oEDFKh3N2e12/lLp9aVSt86veR0TQiCNQXrm8C6aiUQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.0.tgz",
+            "integrity": "sha512-Ipcf3LPNerey1q9ZMjiaWHlNPEHNU/B5/uh9zXLltfEQ1lVSLLeZSgAtTPWGyw8Ip1guOeq+mDtdOlEj/wNxQw==",
             "dev": true,
             "requires": {
+                "serialize-javascript": "^6.0.0",
+                "smob": "^0.0.6",
                 "terser": "^5.15.1"
             }
         },
@@ -7343,11 +7306,6 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
-        },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -9719,6 +9677,15 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -9875,50 +9842,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "rollup-plugin-base64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-base64/-/rollup-plugin-base64-1.0.1.tgz",
-            "integrity": "sha512-IbdX8fjuXO/Op3hYmRPjVo0VwcSenwsQDaDTFdoe+70B5ZGoLMtr96L2yhHXCfxv7HwZVvxZqLsuWj6VwzRt3g==",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^3.1.0"
-            },
-            "dependencies": {
-                "@rollup/pluginutils": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-                    "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-                    "dev": true,
-                    "requires": {
-                        "@types/estree": "0.0.39",
-                        "estree-walker": "^1.0.1",
-                        "picomatch": "^2.2.2"
-                    }
-                },
-                "@types/estree": {
-                    "version": "0.0.39",
-                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-                    "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-                    "dev": true
-                },
-                "estree-walker": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-                    "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-                    "dev": true
-                },
-                "rollup": {
-                    "version": "2.79.1",
-                    "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-                    "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "fsevents": "~2.3.2"
-                    }
-                }
-            }
-        },
         "rollup-plugin-copy": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
@@ -9975,6 +9898,15 @@
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
             "dev": true
         },
+        "serialize-javascript": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -10002,6 +9934,11 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
+        "simple-yenc": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-0.2.3.tgz",
+            "integrity": "sha512-LGufdReGRgj0dXpqpF7j/MQ8SKu4pXAzpkHxQSDI0/GMOlmGY6oivl2hhsyMfAaOGYC6iqcxiDtBy+1MmM4JSA=="
+        },
         "sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10018,6 +9955,12 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true
+        },
+        "smob": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+            "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
             "dev": true
         },
         "socks": {

--- a/rapier-compat/package.json
+++ b/rapier-compat/package.json
@@ -15,18 +15,17 @@
         "all": "npm run build"
     },
     "dependencies": {
-        "base64-js": "^1.5.1"
+        "simple-yenc": "^0.2.3"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-terser": "^0.4.0",
         "@rollup/plugin-typescript": "^9.0.2",
-        "@rollup/plugin-terser": "0.1.0",
         "@types/jest": "^29.2.1",
         "jest": "^29.2.2",
         "rimraf": "^3.0.2",
         "rollup": "^3.2.5",
-        "rollup-plugin-base64": "^1.0.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-filesize": "^9.1.2",
         "ts-jest": "^29.0.3",

--- a/rapier-compat/src2d/init.ts
+++ b/rapier-compat/src2d/init.ts
@@ -1,12 +1,13 @@
 // @ts-ignore
-import wasmBase64 from "../pkg2d/rapier_wasm2d_bg.wasm";
+import wasmYEnc from "../pkg2d/rapier_wasm2d_bg.wasm";
 import wasmInit from "../pkg2d/rapier_wasm2d";
-import base64 from "base64-js";
+// @ts-ignore
+import {decode} from "simple-yenc";
 
 /**
  * Initializes RAPIER.
  * Has to be called and awaited before using any library methods.
  */
-export async function init() {
-    await wasmInit(base64.toByteArray(wasmBase64 as unknown as string).buffer);
+export function init() {
+    return wasmInit(decode(wasmYEnc as unknown as string));
 }

--- a/rapier-compat/src3d/init.ts
+++ b/rapier-compat/src3d/init.ts
@@ -1,12 +1,13 @@
 // @ts-ignore
-import wasmBase64 from "../pkg3d/rapier_wasm3d_bg.wasm";
+import wasmYEnc from "../pkg3d/rapier_wasm3d_bg.wasm";
 import wasmInit from "../pkg3d/rapier_wasm3d";
-import base64 from "base64-js";
+// @ts-ignore
+import {decode} from "simple-yenc";
 
 /**
  * Initializes RAPIER.
  * Has to be called and awaited before using any library methods.
  */
-export async function init() {
-    await wasmInit(base64.toByteArray(wasmBase64 as unknown as string).buffer);
+export function init() {
+    return wasmInit(decode(wasmYEnc as unknown as string));
 }


### PR DESCRIPTION
Hello folks.

I made this PR to test the [`yenc` encoding](https://github.com/eshaz/simple-yenc)

It looks like it produces a bigger encoded string, but it is compressed much better with gzip.

stats for `pkg3d/rapier.es.js`:

```
*yEnc*
Bundle Size:  2.16 MB           
Minified Size:  1.45 MB     
Gzipped Size:  563.37 KB 

*base-64*
Bundle Size:  1.89 MB
Minified Size:  1.89 MB
Gzipped Size:  707.67 KB
```

Feel free to close this PR



