### PR TITLE
Add bindings for the vehicle controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
     method argument to `CharacterController.translationDeltaApplied`, `.translationDeltaRemaining` and the
     `desiredTranslationDelta` to avoid confusion with the usage of the `translation` world in `RigidBody.translation()`.
 
+#### Added
+
+-   Added `DynamicRayCastVehicleController` to simulate vehicles based on ray-casting.
+
 ### 0.11.2
 
 #### Fixed

--- a/src.ts/control/index.ts
+++ b/src.ts/control/index.ts
@@ -1,1 +1,2 @@
 export * from "./character_controller";
+export * from "./ray_cast_vehicle_controller";

--- a/src.ts/control/index.ts
+++ b/src.ts/control/index.ts
@@ -1,2 +1,5 @@
 export * from "./character_controller";
+
+// #if DIM3
 export * from "./ray_cast_vehicle_controller";
+// #endif

--- a/src.ts/control/ray_cast_vehicle_controller.ts
+++ b/src.ts/control/ray_cast_vehicle_controller.ts
@@ -1,0 +1,220 @@
+import {RawKinematicCharacterController, RawDynamicRayCastVehicleController} from "../raw";
+import {Rotation, Vector, VectorOps} from "../math";
+import {Collider, ColliderSet, InteractionGroups, Shape} from "../geometry";
+import {QueryFilterFlags, QueryPipeline, World} from "../pipeline";
+import {IntegrationParameters, RigidBody, RigidBodyHandle, RigidBodySet} from "../dynamics";
+
+export class DynamicRayCastVehicleController {
+    private raw: RawDynamicRayCastVehicleController;
+    private bodies: RigidBodySet;
+    private colliders: ColliderSet;
+    private queries: QueryPipeline;
+
+    constructor(
+        chassis: RigidBody,
+        bodies: RigidBodySet,
+        colliders: ColliderSet,
+        queries: QueryPipeline,
+    ) {
+        this.raw = new RawDynamicRayCastVehicleController(chassis.handle);
+        this.bodies = bodies;
+        this.colliders = colliders;
+        this.queries = queries;
+    }
+
+    /** @internal */
+    public free() {
+        if (!!this.raw) {
+            this.raw.free();
+        }
+
+        this.raw = undefined;
+    }
+
+    public updateVehicle(
+        dt: number,
+        filterFlags?: QueryFilterFlags,
+        filterGroups?: InteractionGroups,
+        filterPredicate?: (collider: Collider) => boolean,
+    ) {
+        this.raw.update_vehicle(
+            dt,
+            this.bodies.raw,
+            this.colliders.raw,
+            this.queries.raw,
+            filterFlags,
+            filterGroups,
+            this.colliders.castClosure(filterPredicate)
+        )
+    }
+
+    public currentVehicleSpeed(): number {
+        return this.raw.current_vehicle_speed();
+    }
+
+    public chassis(): RigidBodyHandle {
+        return this.raw.chassis();
+    }
+
+    get indexUpAxis(): number {
+        return this.raw.index_up_axis();
+    }
+    set indexUpAxis(axis: number) {
+        this.raw.set_index_up_axis(axis);
+    }
+
+    get indexForwardAxis(): number {
+        return this.raw.index_forward_axis();
+    }
+    set setIndexForwardAxis(axis: number) {
+        this.raw.set_index_forward_axis(axis);
+    }
+
+    public addWheel(
+        chassisConnectionCs: Vector,
+        directionCs: Vector,
+        axleCs: Vector,
+        suspensionRestLength: number,
+        radius: number,
+    ) {
+        let rawChassisConnectionCs = VectorOps.intoRaw(chassisConnectionCs);
+        let rawDirectionCs = VectorOps.intoRaw(directionCs);
+        let rawAxleCs = VectorOps.intoRaw(axleCs);
+
+        this.raw.add_wheel(rawChassisConnectionCs, rawDirectionCs, rawAxleCs, suspensionRestLength, radius);
+
+        rawChassisConnectionCs.free();
+        rawDirectionCs.free();
+        rawAxleCs.free();
+    }
+
+    public numWheels(): number {
+        return this.raw.num_wheels();
+    }
+
+
+
+    /*
+     *
+     * Access to wheel properties.
+     *
+     */
+    /*
+     * Getters + setters
+     */
+    public wheelChassisConnectionPointCs(i: number): Vector | null {
+        return VectorOps.fromRaw(this.raw.wheel_chassis_connection_point_cs(i));
+    }
+    public setWheelChassisConnectionPointCs(i: number, value: Vector) {
+        let rawValue = VectorOps.intoRaw(value);
+        this.raw.set_wheel_chassis_connection_point_cs(i, value);
+        rawValue.free();
+    }
+
+    public wheelSuspensionRestLength(i: number): number | null {
+        return this.raw.wheel_suspension_rest_length(i);
+    }
+    public setWheelSuspensionRestLength(i: number, value: number) {
+        this.raw.set_wheel_suspension_rest_length(i, value);
+    }
+
+    public wheelMaxSuspensionTravel(i: number): number | null {
+        return this.raw.wheel_max_suspension_travel(i);
+    }
+    public setMaxSuspensionTravel(i: number, value: number) {
+        this.raw.set_max_suspension_travel(i, value);
+    }
+
+    public wheelRadius(i: number): number | null {
+        return this.raw.wheel_radius(i);
+    }
+    public setWheelRadius(i: number, value: number) {
+        this.raw.set_wheel_radius(i, value);
+    }
+
+    public wheelSuspensionStiffness(i: number): number | null {
+        return this.raw.wheel_suspension_stiffness(i);
+    }
+    public setSuspensionStiffness(i: number, value: number) {
+        this.raw.set_suspension_stiffness(i, value);
+    }
+
+    public wheelSuspensionCompression(i: number): number | null {
+        return this.raw.wheel_suspension_compression(i);
+    }
+    public setSuspensionCompression(i: number, value: number) {
+        this.raw.set_suspension_compression(i, value);
+    }
+
+    public wheelSuspensionRelaxation(i: number): number | null {
+        return this.raw.wheel_suspension_relaxation(i);
+    }
+    public setSuspensionRelaxation(i: number, value: number) {
+        this.raw.set_suspension_relaxation(i, value);
+    }
+
+    public wheelMaxSuspensionForce(i: number): number | null {
+        return this.raw.wheel_max_suspension_force(i);
+    }
+    public setWheelMaxSuspensionForce(i: number, value: number) {
+        this.raw.set_wheel_max_suspension_force(i, value);
+    }
+
+    public wheelBrake(i: number): number | null {
+        return this.raw.wheel_brake(i);
+    }
+    public setWheelBrake(i: number, value: number) {
+        this.raw.set_wheel_brake(i, value);
+    }
+
+    public wheelSteering(i: number): number | null {
+        return this.raw.wheel_steering(i);
+    }
+    public setWheelSteering(i: number, value: number) {
+        this.raw.set_wheel_steering(i, value);
+    }
+
+    public wheelEngineForce(i: number): number | null {
+        return this.raw.wheel_engine_force(i);
+    }
+    public setWheelEngineForce(i: number, value: number) {
+        this.raw.set_wheel_engine_force(i, value);
+    }
+
+    public wheelDirectionCs(i: number): Vector | null {
+        return VectorOps.fromRaw(this.raw.wheel_direction_cs(i));
+    }
+    public setWheelDirectionCs(i: number, value: Vector) {
+        let rawValue = VectorOps.intoRaw(value);
+        this.raw.set_wheel_direction_cs(i, value);
+        rawValue.free();
+    }
+
+    public wheelAxleCs(i: number): Vector | null {
+        return  VectorOps.fromRaw(this.raw.wheel_axle_cs(i));
+    }
+    public setWheelAxleCs(i: number, value: Vector) {
+        let rawValue = VectorOps.intoRaw(value);
+        this.raw.set_wheel_axle_cs(i, value);
+        rawValue.free();
+    }
+
+    /*
+     * Getters only.
+     */
+    public wheelRotation(i: number): number | null {
+        return this.raw.wheel_rotation(i);
+    }
+
+    public wheelForwardImpulse(i: number): number | null {
+        return this.raw.wheel_forward_impulse(i);
+    }
+
+    public wheelSideImpulse(i: number): number | null {
+        return this.raw.wheel_side_impulse(i);
+    }
+
+    public wheelSuspensionForce(i: number): number | null {
+        return this.raw.wheel_suspension_force(i);
+    }
+}

--- a/src.ts/control/ray_cast_vehicle_controller.ts
+++ b/src.ts/control/ray_cast_vehicle_controller.ts
@@ -12,6 +12,7 @@ export class DynamicRayCastVehicleController {
     private bodies: RigidBodySet;
     private colliders: ColliderSet;
     private queries: QueryPipeline;
+    private _chassis: RigidBody;
 
     constructor(
         chassis: RigidBody,
@@ -23,6 +24,7 @@ export class DynamicRayCastVehicleController {
         this.bodies = bodies;
         this.colliders = colliders;
         this.queries = queries;
+        this._chassis = chassis;
     }
 
     /** @internal */
@@ -57,8 +59,8 @@ export class DynamicRayCastVehicleController {
             this.queries.raw,
             filterFlags,
             filterGroups,
-            this.colliders.castClosure(filterPredicate)
-        )
+            this.colliders.castClosure(filterPredicate),
+        );
     }
 
     /**
@@ -71,8 +73,8 @@ export class DynamicRayCastVehicleController {
     /**
      * The rigid-body used as the chassis.
      */
-    public chassis(): RigidBodyHandle {
-        return this.raw.chassis();
+    public chassis(): RigidBody {
+        return this._chassis;
     }
 
     /**
@@ -123,7 +125,13 @@ export class DynamicRayCastVehicleController {
         let rawDirectionCs = VectorOps.intoRaw(directionCs);
         let rawAxleCs = VectorOps.intoRaw(axleCs);
 
-        this.raw.add_wheel(rawChassisConnectionCs, rawDirectionCs, rawAxleCs, suspensionRestLength, radius);
+        this.raw.add_wheel(
+            rawChassisConnectionCs,
+            rawDirectionCs,
+            rawAxleCs,
+            suspensionRestLength,
+            radius,
+        );
 
         rawChassisConnectionCs.free();
         rawDirectionCs.free();
@@ -136,8 +144,6 @@ export class DynamicRayCastVehicleController {
     public numWheels(): number {
         return this.raw.num_wheels();
     }
-
-
 
     /*
      *
@@ -159,7 +165,7 @@ export class DynamicRayCastVehicleController {
      */
     public setWheelChassisConnectionPointCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
-        this.raw.set_wheel_chassis_connection_point_cs(i, value);
+        this.raw.set_wheel_chassis_connection_point_cs(i, rawValue);
         rawValue.free();
     }
 
@@ -187,8 +193,8 @@ export class DynamicRayCastVehicleController {
     /**
      * Sets the maximum distance the i-th wheel suspension can travel before and after its resting length.
      */
-    public setMaxSuspensionTravel(i: number, value: number) {
-        this.raw.set_max_suspension_travel(i, value);
+    public setWheelMaxSuspensionTravel(i: number, value: number) {
+        this.raw.set_wheel_max_suspension_travel(i, value);
     }
 
     /**
@@ -219,8 +225,8 @@ export class DynamicRayCastVehicleController {
      *
      * Increase this value if the suspension appears to not push the vehicle strong enough.
      */
-    public setSuspensionStiffness(i: number, value: number) {
-        this.raw.set_suspension_stiffness(i, value);
+    public setWheelSuspensionStiffness(i: number, value: number) {
+        this.raw.set_wheel_suspension_stiffness(i, value);
     }
 
     /**
@@ -233,8 +239,8 @@ export class DynamicRayCastVehicleController {
     /**
      * The i-th wheel’s suspension’s damping when it is being compressed.
      */
-    public setSuspensionCompression(i: number, value: number) {
-        this.raw.set_suspension_compression(i, value);
+    public setWheelSuspensionCompression(i: number, value: number) {
+        this.raw.set_wheel_suspension_compression(i, value);
     }
 
     /**
@@ -251,8 +257,8 @@ export class DynamicRayCastVehicleController {
      *
      * Increase this value if the suspension appears to overshoot.
      */
-    public setSuspensionRelaxation(i: number, value: number) {
-        this.raw.set_suspension_relaxation(i, value);
+    public setWheelSuspensionRelaxation(i: number, value: number) {
+        this.raw.set_wheel_suspension_relaxation(i, value);
     }
 
     /**
@@ -327,7 +333,7 @@ export class DynamicRayCastVehicleController {
      */
     public setWheelDirectionCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
-        this.raw.set_wheel_direction_cs(i, value);
+        this.raw.set_wheel_direction_cs(i, rawValue);
         rawValue.free();
     }
 
@@ -337,7 +343,7 @@ export class DynamicRayCastVehicleController {
      * The axis index defined as 0 = X, 1 = Y, 2 = Z.
      */
     public wheelAxleCs(i: number): Vector | null {
-        return  VectorOps.fromRaw(this.raw.wheel_axle_cs(i));
+        return VectorOps.fromRaw(this.raw.wheel_axle_cs(i));
     }
 
     /**
@@ -347,7 +353,7 @@ export class DynamicRayCastVehicleController {
      */
     public setWheelAxleCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
-        this.raw.set_wheel_axle_cs(i, value);
+        this.raw.set_wheel_axle_cs(i, rawValue);
         rawValue.free();
     }
 

--- a/src.ts/control/ray_cast_vehicle_controller.ts
+++ b/src.ts/control/ray_cast_vehicle_controller.ts
@@ -1,9 +1,12 @@
-import {RawKinematicCharacterController, RawDynamicRayCastVehicleController} from "../raw";
-import {Rotation, Vector, VectorOps} from "../math";
-import {Collider, ColliderSet, InteractionGroups, Shape} from "../geometry";
-import {QueryFilterFlags, QueryPipeline, World} from "../pipeline";
-import {IntegrationParameters, RigidBody, RigidBodyHandle, RigidBodySet} from "../dynamics";
+import {RawDynamicRayCastVehicleController} from "../raw";
+import {Vector, VectorOps} from "../math";
+import {Collider, ColliderSet, InteractionGroups} from "../geometry";
+import {QueryFilterFlags, QueryPipeline} from "../pipeline";
+import {RigidBody, RigidBodyHandle, RigidBodySet} from "../dynamics";
 
+/**
+ * A character controller to simulate vehicles using ray-casting for the wheels.
+ */
 export class DynamicRayCastVehicleController {
     private raw: RawDynamicRayCastVehicleController;
     private bodies: RigidBodySet;
@@ -31,6 +34,16 @@ export class DynamicRayCastVehicleController {
         this.raw = undefined;
     }
 
+    /**
+     * Updates the vehicle’s velocity based on its suspension, engine force, and brake.
+     *
+     * This directly updates the velocity of its chassis rigid-body.
+     *
+     * @param dt - Time increment used to integrate forces.
+     * @param filterFlags - Flag to exclude categories of objects from the wheels’ ray-cast.
+     * @param filterGroups - Only colliders compatible with these groups will be hit by the wheels’ ray-casts.
+     * @param filterPredicate - Callback to filter out which collider will be hit by the wheels’ ray-casts.
+     */
     public updateVehicle(
         dt: number,
         filterFlags?: QueryFilterFlags,
@@ -48,28 +61,57 @@ export class DynamicRayCastVehicleController {
         )
     }
 
+    /**
+     * The current forward speed of the vehicle.
+     */
     public currentVehicleSpeed(): number {
         return this.raw.current_vehicle_speed();
     }
 
+    /**
+     * The rigid-body used as the chassis.
+     */
     public chassis(): RigidBodyHandle {
         return this.raw.chassis();
     }
 
+    /**
+     * The chassis’ local _up_ direction (`0 = x, 1 = y, 2 = z`).
+     */
     get indexUpAxis(): number {
         return this.raw.index_up_axis();
     }
+
+    /**
+     * Sets the chassis’ local _up_ direction (`0 = x, 1 = y, 2 = z`).
+     */
     set indexUpAxis(axis: number) {
         this.raw.set_index_up_axis(axis);
     }
 
+    /**
+     * The chassis’ local _forward_ direction (`0 = x, 1 = y, 2 = z`).
+     */
     get indexForwardAxis(): number {
         return this.raw.index_forward_axis();
     }
+
+    /**
+     * Sets the chassis’ local _forward_ direction (`0 = x, 1 = y, 2 = z`).
+     */
     set setIndexForwardAxis(axis: number) {
         this.raw.set_index_forward_axis(axis);
     }
 
+    /**
+     * Adds a new wheel attached to this vehicle.
+     * @param chassisConnectionCs  - The position of the wheel relative to the chassis.
+     * @param directionCs - The direction of the wheel’s suspension, relative to the chassis. The ray-casting will
+     *                      happen following this direction to detect the ground.
+     * @param axleCs - The wheel’s axle axis, relative to the chassis.
+     * @param suspensionRestLength - The rest length of the wheel’s suspension spring.
+     * @param radius - The wheel’s radius.
+     */
     public addWheel(
         chassisConnectionCs: Vector,
         directionCs: Vector,
@@ -88,6 +130,9 @@ export class DynamicRayCastVehicleController {
         rawAxleCs.free();
     }
 
+    /**
+     * The number of wheels attached to this vehicle.
+     */
     public numWheels(): number {
         return this.raw.num_wheels();
     }
@@ -102,97 +147,204 @@ export class DynamicRayCastVehicleController {
     /*
      * Getters + setters
      */
+    /**
+     * The position of the i-th wheel, relative to the chassis.
+     */
     public wheelChassisConnectionPointCs(i: number): Vector | null {
         return VectorOps.fromRaw(this.raw.wheel_chassis_connection_point_cs(i));
     }
+
+    /**
+     * Sets the position of the i-th wheel, relative to the chassis.
+     */
     public setWheelChassisConnectionPointCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
         this.raw.set_wheel_chassis_connection_point_cs(i, value);
         rawValue.free();
     }
 
+    /**
+     * The rest length of the i-th wheel’s suspension spring.
+     */
     public wheelSuspensionRestLength(i: number): number | null {
         return this.raw.wheel_suspension_rest_length(i);
     }
+
+    /**
+     * Sets the rest length of the i-th wheel’s suspension spring.
+     */
     public setWheelSuspensionRestLength(i: number, value: number) {
         this.raw.set_wheel_suspension_rest_length(i, value);
     }
 
+    /**
+     * The maximum distance the i-th wheel suspension can travel before and after its resting length.
+     */
     public wheelMaxSuspensionTravel(i: number): number | null {
         return this.raw.wheel_max_suspension_travel(i);
     }
+
+    /**
+     * Sets the maximum distance the i-th wheel suspension can travel before and after its resting length.
+     */
     public setMaxSuspensionTravel(i: number, value: number) {
         this.raw.set_max_suspension_travel(i, value);
     }
 
+    /**
+     * The i-th wheel’s radius.
+     */
     public wheelRadius(i: number): number | null {
         return this.raw.wheel_radius(i);
     }
+
+    /**
+     * Sets the i-th wheel’s radius.
+     */
     public setWheelRadius(i: number, value: number) {
         this.raw.set_wheel_radius(i, value);
     }
 
+    /**
+     * The i-th wheel’s suspension stiffness.
+     *
+     * Increase this value if the suspension appears to not push the vehicle strong enough.
+     */
     public wheelSuspensionStiffness(i: number): number | null {
         return this.raw.wheel_suspension_stiffness(i);
     }
+
+    /**
+     * Sets the i-th wheel’s suspension stiffness.
+     *
+     * Increase this value if the suspension appears to not push the vehicle strong enough.
+     */
     public setSuspensionStiffness(i: number, value: number) {
         this.raw.set_suspension_stiffness(i, value);
     }
 
+    /**
+     * The i-th wheel’s suspension’s damping when it is being compressed.
+     */
     public wheelSuspensionCompression(i: number): number | null {
         return this.raw.wheel_suspension_compression(i);
     }
+
+    /**
+     * The i-th wheel’s suspension’s damping when it is being compressed.
+     */
     public setSuspensionCompression(i: number, value: number) {
         this.raw.set_suspension_compression(i, value);
     }
 
+    /**
+     * The i-th wheel’s suspension’s damping when it is being released.
+     *
+     * Increase this value if the suspension appears to overshoot.
+     */
     public wheelSuspensionRelaxation(i: number): number | null {
         return this.raw.wheel_suspension_relaxation(i);
     }
+
+    /**
+     * Sets the i-th wheel’s suspension’s damping when it is being released.
+     *
+     * Increase this value if the suspension appears to overshoot.
+     */
     public setSuspensionRelaxation(i: number, value: number) {
         this.raw.set_suspension_relaxation(i, value);
     }
 
+    /**
+     * The maximum force applied by the i-th wheel’s suspension.
+     */
     public wheelMaxSuspensionForce(i: number): number | null {
         return this.raw.wheel_max_suspension_force(i);
     }
+
+    /**
+     * Sets the maximum force applied by the i-th wheel’s suspension.
+     */
     public setWheelMaxSuspensionForce(i: number, value: number) {
         this.raw.set_wheel_max_suspension_force(i, value);
     }
 
+    /**
+     * The maximum amount of braking impulse applied on the i-th wheel to slow down the vehicle.
+     */
     public wheelBrake(i: number): number | null {
         return this.raw.wheel_brake(i);
     }
+
+    /**
+     * Set the maximum amount of braking impulse applied on the i-th wheel to slow down the vehicle.
+     */
     public setWheelBrake(i: number, value: number) {
         this.raw.set_wheel_brake(i, value);
     }
 
+    /**
+     * The steering angle (radians) for the i-th wheel.
+     */
     public wheelSteering(i: number): number | null {
         return this.raw.wheel_steering(i);
     }
+
+    /**
+     * Sets the steering angle (radians) for the i-th wheel.
+     */
     public setWheelSteering(i: number, value: number) {
         this.raw.set_wheel_steering(i, value);
     }
 
+    /**
+     * The forward force applied by the i-th wheel on the chassis.
+     */
     public wheelEngineForce(i: number): number | null {
         return this.raw.wheel_engine_force(i);
     }
+
+    /**
+     * Sets the forward force applied by the i-th wheel on the chassis.
+     */
     public setWheelEngineForce(i: number, value: number) {
         this.raw.set_wheel_engine_force(i, value);
     }
 
+    /**
+     * The direction of the i-th wheel’s suspension, relative to the chassis.
+     *
+     * The ray-casting will happen following this direction to detect the ground.
+     */
     public wheelDirectionCs(i: number): Vector | null {
         return VectorOps.fromRaw(this.raw.wheel_direction_cs(i));
     }
+
+    /**
+     * Sets the direction of the i-th wheel’s suspension, relative to the chassis.
+     *
+     * The ray-casting will happen following this direction to detect the ground.
+     */
     public setWheelDirectionCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
         this.raw.set_wheel_direction_cs(i, value);
         rawValue.free();
     }
 
+    /**
+     * The i-th wheel’s axle axis, relative to the chassis.
+     *
+     * The axis index defined as 0 = X, 1 = Y, 2 = Z.
+     */
     public wheelAxleCs(i: number): Vector | null {
         return  VectorOps.fromRaw(this.raw.wheel_axle_cs(i));
     }
+
+    /**
+     * Sets the i-th wheel’s axle axis, relative to the chassis.
+     *
+     * The axis index defined as 0 = X, 1 = Y, 2 = Z.
+     */
     public setWheelAxleCs(i: number, value: Vector) {
         let rawValue = VectorOps.intoRaw(value);
         this.raw.set_wheel_axle_cs(i, value);
@@ -202,18 +354,31 @@ export class DynamicRayCastVehicleController {
     /*
      * Getters only.
      */
+
+    /**
+     *  The i-th wheel’s current rotation angle (radians) on its axle.
+     */
     public wheelRotation(i: number): number | null {
         return this.raw.wheel_rotation(i);
     }
 
+    /**
+     *  The forward impulses applied by the i-th wheel on the chassis.
+     */
     public wheelForwardImpulse(i: number): number | null {
         return this.raw.wheel_forward_impulse(i);
     }
 
+    /**
+     *  The side impulses applied by the i-th wheel on the chassis.
+     */
     public wheelSideImpulse(i: number): number | null {
         return this.raw.wheel_side_impulse(i);
     }
 
+    /**
+     *  The force applied by the i-th wheel suspension.
+     */
     public wheelSuspensionForce(i: number): number | null {
         return this.raw.wheel_suspension_force(i);
     }

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -397,7 +397,9 @@ export class World {
     /**
      * Creates a new vehicle controller.
      *
-     * @param chassis - The rigid-body used as the chassis of the vehicle controller.
+     * @param chassis - The rigid-body used as the chassis of the vehicle controller. When the vehicle
+     *                  controller is updated, it will change directly the rigid-body’s velocity. This
+     *                  rigid-body must be a dynamic or kinematic-velocity-based rigid-body.
      */
     public createVehicleController(
         chassis: RigidBody,

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -54,8 +54,12 @@ import {SerializationPipeline} from "./serialization_pipeline";
 import {EventQueue} from "./event_queue";
 import {PhysicsHooks} from "./physics_hooks";
 import {DebugRenderBuffers, DebugRenderPipeline} from "./debug_render_pipeline";
-import {DynamicRayCastVehicleController, KinematicCharacterController} from "../control";
+import {KinematicCharacterController} from "../control";
 import {Coarena} from "../coarena";
+
+// #if DIM3
+import {DynamicRayCastVehicleController} from "../control";
+// #endif
 
 /**
  * The physics world.
@@ -79,7 +83,10 @@ export class World {
     serializationPipeline: SerializationPipeline;
     debugRenderPipeline: DebugRenderPipeline;
     characterControllers: Set<KinematicCharacterController>;
+
+    // #if DIM3
     vehicleControllers: Set<DynamicRayCastVehicleController>;
+    // #endif
 
     /**
      * Release the WASM memory occupied by this physics world.
@@ -102,7 +109,10 @@ export class World {
         this.serializationPipeline.free();
         this.debugRenderPipeline.free();
         this.characterControllers.forEach((controller) => controller.free());
+
+        // #if DIM3
         this.vehicleControllers.forEach((controller) => controller.free());
+        // #endif
 
         this.integrationParameters = undefined;
         this.islands = undefined;
@@ -118,7 +128,10 @@ export class World {
         this.serializationPipeline = undefined;
         this.debugRenderPipeline = undefined;
         this.characterControllers = undefined;
+
+        // #if DIM3
         this.vehicleControllers = undefined;
+        // #endif
     }
 
     constructor(
@@ -158,7 +171,10 @@ export class World {
             rawDebugRenderPipeline,
         );
         this.characterControllers = new Set<KinematicCharacterController>();
+
+        // #if DIM3
         this.vehicleControllers = new Set<DynamicRayCastVehicleController>();
+        // #endif
 
         this.impulseJoints.finalizeDeserialization(this.bodies);
         this.bodies.finalizeDeserialization(this.colliders);
@@ -393,7 +409,7 @@ export class World {
         controller.free();
     }
 
-
+    // #if DIM3
     /**
      * Creates a new vehicle controller.
      *
@@ -419,10 +435,13 @@ export class World {
      *
      * @param controller - The vehicle controller to remove.
      */
-    public removeVehicleController(controller: DynamicRayCastVehicleController) {
+    public removeVehicleController(
+        controller: DynamicRayCastVehicleController,
+    ) {
         this.vehicleControllers.delete(controller);
         controller.free();
     }
+    // #endif
 
     /**
      * Creates a new collider.

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,3 +1,9 @@
 pub use self::character_controller::RawKinematicCharacterController;
 
+#[cfg(feature = "dim3")]
+pub use self::ray_cast_vehicle_controller::RawDynamicRayCastVehicleController;
+
 mod character_controller;
+
+#[cfg(feature = "dim3")]
+mod ray_cast_vehicle_controller;

--- a/src/control/ray_cast_vehicle_controller.rs
+++ b/src/control/ray_cast_vehicle_controller.rs
@@ -1,0 +1,269 @@
+use crate::dynamics::RawRigidBodySet;
+use crate::geometry::RawColliderSet;
+use crate::math::RawVector;
+use crate::pipeline::RawQueryPipeline;
+use crate::utils::{self, FlatHandle};
+use rapier::control::{DynamicRayCastVehicleController, WheelTuning};
+use rapier::math::Real;
+use rapier::pipeline::{QueryFilter, QueryFilterFlags};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct RawDynamicRayCastVehicleController {
+    controller: DynamicRayCastVehicleController,
+}
+
+#[wasm_bindgen]
+impl RawDynamicRayCastVehicleController {
+    #[wasm_bindgen(constructor)]
+    pub fn new(chassis: FlatHandle) -> Self {
+        Self {
+            controller: DynamicRayCastVehicleController::new(utils::body_handle(chassis)),
+        }
+    }
+
+    pub fn current_vehicle_speed(&self) -> Real {
+        self.controller.current_vehicle_speed
+    }
+
+    pub fn chassis(&self) -> FlatHandle {
+        utils::flat_handle(self.controller.chassis.0)
+    }
+
+    pub fn index_up_axis(&self) -> usize {
+        self.controller.index_up_axis
+    }
+    pub fn set_index_up_axis(&mut self, axis: usize) {
+        self.controller.index_up_axis = axis;
+    }
+
+    pub fn index_forward_axis(&self) -> usize {
+        self.controller.index_forward_axis
+    }
+    pub fn set_index_forward_axis(&mut self, axis: usize) {
+        self.controller.index_forward_axis = axis;
+    }
+
+    pub fn add_wheel(
+        &mut self,
+        chassis_connection_cs: &RawVector,
+        direction_cs: &RawVector,
+        axle_cs: &RawVector,
+        suspension_rest_length: Real,
+        radius: Real,
+    ) {
+        self.controller.add_wheel(
+            chassis_connection_cs.0.into(),
+            direction_cs.0,
+            axle_cs.0,
+            suspension_rest_length,
+            radius,
+            &WheelTuning::default(),
+        );
+    }
+
+    pub fn num_wheels(&self) -> usize {
+        self.controller.wheels().len()
+    }
+
+    pub fn update_vehicle(
+        &mut self,
+        dt: Real,
+        bodies: &mut RawRigidBodySet,
+        colliders: &RawColliderSet,
+        queries: &RawQueryPipeline,
+        filter_flags: u32,
+        filter_groups: Option<u32>,
+        filter_predicate: &js_sys::Function,
+    ) {
+        crate::utils::with_filter(filter_predicate, |predicate| {
+            let query_filter = QueryFilter {
+                flags: QueryFilterFlags::from_bits(filter_flags)
+                    .unwrap_or(QueryFilterFlags::empty()),
+                groups: filter_groups.map(crate::geometry::unpack_interaction_groups),
+                predicate,
+                exclude_rigid_body: Some(self.controller.chassis),
+                exclude_collider: None,
+            };
+
+            self.controller.update_vehicle(
+                dt,
+                &mut bodies.0,
+                &colliders.0,
+                &queries.0,
+                query_filter,
+            );
+        });
+    }
+
+    /*
+     *
+     * Access to wheel properties.
+     *
+     */
+    /*
+     * Getters + setters
+     */
+    pub fn wheel_chassis_connection_point_cs(&self, i: usize) -> Option<RawVector> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.chassis_connection_point_cs.into())
+    }
+    pub fn set_wheel_chassis_connection_point_cs(&mut self, i: usize, value: &RawVector) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.chassis_connection_point_cs = value.0.into();
+        }
+    }
+
+    pub fn wheel_suspension_rest_length(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.suspension_rest_length)
+    }
+    pub fn set_wheel_suspension_rest_length(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.suspension_rest_length = value;
+        }
+    }
+
+    pub fn wheel_max_suspension_travel(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.max_suspension_travel)
+    }
+    pub fn set_wheel_max_suspension_travel(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.max_suspension_travel = value;
+        }
+    }
+
+    pub fn wheel_radius(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.radius)
+    }
+    pub fn set_wheel_radius(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.radius = value;
+        }
+    }
+
+    pub fn wheel_suspension_stiffness(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.suspension_stiffness)
+    }
+    pub fn set_wheel_suspension_stiffness(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.suspension_stiffness = value;
+        }
+    }
+
+    pub fn wheel_suspension_compression(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.damping_compression)
+    }
+    pub fn set_wheel_suspension_compression(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.damping_compression = value;
+        }
+    }
+
+    pub fn wheel_suspension_relaxation(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.damping_relaxation)
+    }
+    pub fn set_wheel_suspension_relaxation(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.damping_relaxation = value;
+        }
+    }
+
+    pub fn wheel_max_suspension_force(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.max_suspension_force)
+    }
+    pub fn set_wheel_max_suspension_force(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.max_suspension_force = value;
+        }
+    }
+
+    pub fn wheel_brake(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.brake)
+    }
+    pub fn set_wheel_brake(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.brake = value;
+        }
+    }
+
+    pub fn wheel_steering(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.steering)
+    }
+    pub fn set_wheel_steering(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.steering = value;
+        }
+    }
+
+    pub fn wheel_engine_force(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.engine_force)
+    }
+    pub fn set_wheel_engine_force(&mut self, i: usize, value: Real) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.engine_force = value;
+        }
+    }
+
+    pub fn wheel_direction_cs(&self, i: usize) -> Option<RawVector> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.direction_cs.into())
+    }
+    pub fn set_wheel_direction_cs(&mut self, i: usize, value: &RawVector) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.direction_cs = value.0;
+        }
+    }
+
+    pub fn wheel_axle_cs(&self, i: usize) -> Option<RawVector> {
+        self.controller.wheels().get(i).map(|w| w.axle_cs.into())
+    }
+    pub fn set_wheel_axle_cs(&mut self, i: usize, value: &RawVector) {
+        if let Some(wheel) = self.controller.wheels_mut().get_mut(i) {
+            wheel.axle_cs = value.0;
+        }
+    }
+
+    /*
+     * Getters only.
+     */
+    pub fn wheel_rotation(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.rotation)
+    }
+
+    pub fn wheel_forward_impulse(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.forward_impulse)
+    }
+
+    pub fn wheel_side_impulse(&self, i: usize) -> Option<Real> {
+        self.controller.wheels().get(i).map(|w| w.side_impulse)
+    }
+
+    pub fn wheel_suspension_force(&self, i: usize) -> Option<Real> {
+        self.controller
+            .wheels()
+            .get(i)
+            .map(|w| w.wheel_suspension_force)
+    }
+}


### PR DESCRIPTION
This makes it possible to use the dynamic vehicle controller based on ray-casts for the wheels that was introduced in Rapier 0.17.