### PR TITLE
Fix typo in "'castShape' functions

### DIFF
--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -847,7 +847,7 @@ export class Collider {
      *   limits the distance traveled by the shape to `collider1Vel.norm() * maxToi`.
      * @param stopAtPenetration - If set to `false`, the linear shape-cast won’t immediately stop if
      *   the shape is penetrating another shape at its starting point **and** its trajectory is such
-     *   that it’s on a path to exist that penetration state.
+     *   that it’s on a path to exit that penetration state.
      */
     public castShape(
         collider1Vel: Vector,
@@ -901,7 +901,7 @@ export class Collider {
      *   limits the distance traveled by the shape to `shapeVel.norm() * maxToi`.
      * @param stopAtPenetration - If set to `false`, the linear shape-cast won’t immediately stop if
      *   the shape is penetrating another shape at its starting point **and** its trajectory is such
-     *   that it’s on a path to exist that penetration state.
+     *   that it’s on a path to exit that penetration state.
      */
     public castCollider(
         collider1Vel: Vector,

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -211,7 +211,7 @@ export abstract class Shape {
      * @param maxToi - The maximum time when the impact can happen.
      * @param stopAtPenetration - If set to `false`, the linear shape-cast won’t immediately stop if
      *   the shape is penetrating another shape at its starting point **and** its trajectory is such
-     *   that it’s on a path to exist that penetration state.
+     *   that it’s on a path to exit that penetration state.
      * @returns If the two moving shapes collider at some point along their trajectories, this returns the
      *  time at which the two shape collider as well as the contact information during the impact. Returns
      *  `null`if the two shapes never collide along their paths.

--- a/src.ts/pipeline/query_pipeline.ts
+++ b/src.ts/pipeline/query_pipeline.ts
@@ -424,7 +424,7 @@ export class QueryPipeline {
      *   limits the distance traveled by the shape to `shapeVel.norm() * maxToi`.
      * @param stopAtPenetration - If set to `false`, the linear shape-cast won’t immediately stop if
      *   the shape is penetrating another shape at its starting point **and** its trajectory is such
-     *   that it’s on a path to exist that penetration state.
+     *   that it’s on a path to exit that penetration state.
      * @param groups - The bit groups and filter associated to the shape to cast, in order to only
      *   test on colliders with collision groups compatible with this group.
      */

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -953,7 +953,7 @@ export class World {
      *   limits the distance traveled by the shape to `shapeVel.norm() * maxToi`.
      * @param stopAtPenetration - If set to `false`, the linear shape-cast won’t immediately stop if
      *   the shape is penetrating another shape at its starting point **and** its trajectory is such
-     *   that it’s on a path to exist that penetration state.
+     *   that it’s on a path to exit that penetration state.
      * @param groups - The bit groups and filter associated to the shape to cast, in order to only
      *   test on colliders with collision groups compatible with this group.
      */


### PR DESCRIPTION
I'm not 100% sure ; the sentence "on a path to exist that penetration state" feels a bit weird, I'm not sure if I could read it either:
- "enter" that penetration state
- or it's a typo ? "exit" that penetration state