### PR TITLE
Update GitHub action artifacts to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
                   cd rapier3d;
                   npm ci;
                   npm run build;
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                   name: pkg ${{ matrix.os }}
                   path: |
@@ -65,13 +65,14 @@ jobs:
                       rapier3d/pkg
                       rapier-compat/pkg2d
                       rapier-compat/pkg3d
+                  overwrite: true
     publish:
         runs-on: ubuntu-latest
         needs: build
         if: github.ref == 'refs/heads/master'
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: pkg ubuntu-latest
             - uses: actions/setup-node@v3


### PR DESCRIPTION
Should fix the failing CI

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/