### PR TITLE
Fix rapier(x)d-simd-compat to use simd instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,29 @@ jobs:
                   npm ci;
                   npm run build;
                   npm run test;
+            # Install dependencies to check simd for builds
+            - name: Install wabt
+              run: |
+                  sudo apt install wabt;
+            # Check simd for rust builds
+            - name: Check 2d simd rust build
+              run: |
+                  wasm-objdump -d builds/rapier2d/pkg/rapier_wasm2d_bg.wasm | grep :\\sfd
+                  || >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1
+            - name: Check 3d simd compat build
+              run: |
+                  wasm-objdump -d builds/rapier3d/pkg/rapier_wasm3d_bg.wasm | grep :\\sfd
+                  || >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1
+            # Check simd for compat builds
+            - name: Check 2d simd compat build
+              run: |
+                  wasm-objdump -d rapier-compat/builds/2d-simd/wasm-build/rapier_wasm2d_bg.wasm | grep :\\sfd
+                  || >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1
+            - name: Check 3d simd compat build
+              run: |
+                  wasm-objdump -d rapier-compat/builds/3d-simd/wasm-build/rapier_wasm3d_bg.wasm | grep :\\sfd
+                  || >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1
+            # Upload
             - uses: actions/upload-artifact@v4
               with:
                   name: pkg ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,26 @@ jobs:
             - name: Build all no-compat projects
               run: |
                   ./builds/prepare_builds/build_all_projects.sh
+            # Install dependencies to check simd for builds
+            - name: Install wabt
+              run: |
+                  sudo apt install wabt;
+              if: matrix.os == 'ubuntu-latest'
+            - name: Install wabt
+              run: |
+                  brew install wabt;
+              if: matrix.os == 'macos-latest'
+            # Check simd for rust builds
+            - name: Check 2d simd rust build
+              run: |
+                  if ! wasm-objdump -d builds/rapier2d-simd/pkg/rapier_wasm2d_bg.wasm | grep :\\sfd ; then
+                    >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1
+                  fi
+            - name: Check 3d simd compat build
+              run: |
+                  if ! wasm-objdump -d builds/rapier3d-simd/pkg/rapier_wasm3d_bg.wasm | grep :\\sfd ; then
+                    >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1
+                  fi
             - uses: actions/upload-artifact@v4
               with:
                   name: pkg ${{ matrix.os }}
@@ -86,24 +106,22 @@ jobs:
             - name: Install wabt
               run: |
                   sudo apt install wabt;
-            # Check simd for rust builds
-            - name: Check 2d simd rust build
+              if: matrix.os == 'ubuntu-latest'
+            - name: Install wabt
               run: |
-                  wasm-objdump -d builds/rapier2d/pkg/rapier_wasm2d_bg.wasm | grep :\\sfd
-                  || >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1
-            - name: Check 3d simd compat build
-              run: |
-                  wasm-objdump -d builds/rapier3d/pkg/rapier_wasm3d_bg.wasm | grep :\\sfd
-                  || >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1
+                  brew install wabt;
+              if: matrix.os == 'macos-latest'
             # Check simd for compat builds
             - name: Check 2d simd compat build
               run: |
-                  wasm-objdump -d rapier-compat/builds/2d-simd/wasm-build/rapier_wasm2d_bg.wasm | grep :\\sfd
-                  || >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1
+                  if ! wasm-objdump -d rapier-compat/builds/2d-simd/pkg/rapier_wasm2d_bg.wasm | grep :\\sfd ; then
+                    >&2 echo "ERROR: 2d simd compat build does not include simd opcode prefix." && exit 1;
+                  fi
             - name: Check 3d simd compat build
               run: |
-                  wasm-objdump -d rapier-compat/builds/3d-simd/wasm-build/rapier_wasm3d_bg.wasm | grep :\\sfd
-                  || >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1
+                  if ! wasm-objdump -d rapier-compat/builds/3d-simd/pkg/rapier_wasm3d_bg.wasm | grep :\\sfd ; then
+                    >&2 echo "ERROR: 3d simd compat build does not include simd opcode prefix." && exit 1;
+                  fi
             # Upload
             - uses: actions/upload-artifact@v4
               with:

--- a/builds/prepare_builds/templates/build_rust.sh.tera
+++ b/builds/prepare_builds/templates/build_rust.sh.tera
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Cleaning rust because changing rust flags may lead to different build results.
+cargo clean
+
 {{ additional_rust_flags }} npx wasm-pack build
 sed -i.bak 's#dimforge_rapier#@dimforge/rapier#g' pkg/package.json
 sed -i.bak 's/"rapier_wasm{{ dimension }}d_bg.wasm"/"*"/g' pkg/package.json

--- a/rapier-compat/build-rust.sh
+++ b/rapier-compat/build-rust.sh
@@ -41,4 +41,10 @@ fi
 
 # Working dir in wasm-pack is the project root so we need that "../../"
 
-wasm-pack build --target web --out-dir "../../rapier-compat/builds/${dimension}d${feature_postfix}/wasm-build" "$rust_source_directory"
+if [[ $feature == "simd" ]]; then
+    export additional_rustflags='-C target-feature=+simd128'
+else
+    export additional_rustflags=''
+fi
+
+RUSTFLAGS="${additional_rustflags}" wasm-pack --verbose build --target web --out-dir "../../rapier-compat/builds/${dimension}d${feature_postfix}/wasm-build" "$rust_source_directory"


### PR DESCRIPTION
- Fix https://github.com/dimforge/rapier.js/issues/314

- [x] run `cargo clean` to avoid reusing previously compiled crate ; while this doesn't help much with linked issue, I believe that's a sensible thing to do which will avoid surprises in the long run, so I'd argue to keep it, we're not benefitting much from incremental compilation speed if  it comes at a price of sneaky build differences.
- [x] add simd rustflags when building rapier-compat simd -> that's the real fix.
- [x] TODO: add a CI check ; to avoid regressions