### PR TITLE
Add support for voxels colliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### 0.16.0 (24 April 2025)
+
+### Added
+
+- Added `ColliderDesc.voxels` to create a collider with a shape optimized for voxels.
+- Added `Collider.setVoxel` for adding or removing a voxel from a collider with a voxel shape.
+- Added the `Voxels` shape class.
+
+The support or voxels is still experimental. In particular the following features will currently **not** work on
+colliders with voxel shapes:
+
+- Voxels colliders attached to dynamic rigid-bodies will not run the automatic mass/angular inertia calculation.
+- Shape-casting on voxel shapes/colliders.
+- Collision-detection between two-voxels colliders, or a voxels collider and a mesh, polyline, or heightfield.
+
+See [parry#336](https://github.com/dimforge/parry/pull/336) for additional information.
+
 ### 0.15.1 (10 April 2025)
 
 #### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-deterministic"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-simd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-deterministic"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-simd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -486,9 +486,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ce92fd1b7aaf2d7eb1631c566d751e56104152bf6ea95a1f3a7e8daf923d5c"
+checksum = "8bcca0d91ccd7a49aec62565bcfc8dae9fd449e7fda420d51a2da84f8d86bda0"
 dependencies = [
  "approx",
  "arrayvec",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f0d5730859f8326b26c8057aae09b790804f3e6c9dec38f4b2a1b91664529"
+checksum = "69a8e71e0a9e6d648dce948bdd95568c7f5ccf2ce2d19908ef5a68c9bf550972"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "rapier2d"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caf6613d797c5564c304b7579c78addd922fbfe3fd6a22a01130892546d3794"
+checksum = "8bfd38bab4c05990316884af854aa7b79e38386c8aa9a19c3bafb3718395aa8c"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106edf55a415c64d2dccbb79faa2085e2bd02ded26b41b399b04b90219484c7e"
+checksum = "e5880578346b99f4d0f449f1daca5cd66f5ac72ad22606b021a6b8507d75782a"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "spade"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.24.0", features = [
+rapier{{ dimension }}d = { version = "0.25.0", features = [
     "serde-serialize",
     "debug-render",
     {%- for feature in additional_features %}

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -672,19 +672,19 @@ export class Collider {
     public setVoxel(
         ix: number,
         iy: number,
-// #if DIM3
+        // #if DIM3
         iz: number,
-// #endif
+        // #endif
         filled: boolean,
     ) {
         this.colliderSet.raw.coSetVoxel(
             this.handle,
             ix,
             iy,
-// #if DIM3
+            // #if DIM3
             iz,
-// #endif
-            filled
+            // #endif
+            filled,
         );
         // We modified the shape, invalidate it to keep our cache
         // up-to-date the next time the user requests the shape data.
@@ -1286,7 +1286,7 @@ export class ColliderDesc {
     public static voxels(
         voxels: Float32Array | Int32Array,
         voxelSize: Vector,
-        primitiveGeometry?: RawVoxelPrimitiveGeometry
+        primitiveGeometry?: RawVoxelPrimitiveGeometry,
     ): ColliderDesc {
         const shape = new Voxels(voxels, voxelSize, primitiveGeometry);
         return new ColliderDesc(shape);

--- a/src.ts/geometry/shape.ts
+++ b/src.ts/geometry/shape.ts
@@ -1,5 +1,10 @@
 import {Vector, VectorOps, Rotation, RotationOps} from "../math";
-import {RawColliderSet, RawShape, RawShapeType, RawVoxelPrimitiveGeometry} from "../raw";
+import {
+    RawColliderSet,
+    RawShape,
+    RawShapeType,
+    RawVoxelPrimitiveGeometry,
+} from "../raw";
 import {ShapeContact} from "./contact";
 import {PointProjection} from "./point";
 import {Ray, RayIntersection} from "./ray";
@@ -1064,15 +1069,14 @@ export class Voxels extends Shape {
     constructor(
         data: Float32Array | Int32Array,
         voxelSize: Vector,
-        primitiveGeometry?: RawVoxelPrimitiveGeometry
+        primitiveGeometry?: RawVoxelPrimitiveGeometry,
     ) {
         super();
         this.data = data;
         this.voxelSize = voxelSize;
         if (primitiveGeometry !== undefined)
             this.primitiveGeometry = primitiveGeometry;
-        else
-            this.primitiveGeometry = RawVoxelPrimitiveGeometry.PseudoCube;
+        else this.primitiveGeometry = RawVoxelPrimitiveGeometry.PseudoCube;
     }
 
     public intoRaw(): RawShape {
@@ -1080,9 +1084,17 @@ export class Voxels extends Shape {
 
         let result;
         if (this.data instanceof Int32Array) {
-            result = RawShape.voxels(this.primitiveGeometry, voxelSize, this.data);
+            result = RawShape.voxels(
+                this.primitiveGeometry,
+                voxelSize,
+                this.data,
+            );
         } else {
-            result = RawShape.voxelsFromPoints(this.primitiveGeometry, voxelSize, this.data);
+            result = RawShape.voxelsFromPoints(
+                this.primitiveGeometry,
+                voxelSize,
+                this.data,
+            );
         }
 
         voxelSize.free();

--- a/testbed2d/package-lock.json
+++ b/testbed2d/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@dimforge/rapier2d": "file:../rapier2d",
+                "@dimforge/rapier2d": "file:../builds/rapier2d",
                 "hash-wasm": "^4.12.0",
                 "lil-gui": "^0.17.0",
                 "pixi-viewport": "^4.37.0",
@@ -29,7 +29,7 @@
                 "webpack-dev-server": "^4.11.1"
             }
         },
-        "../rapier2d": {
+        "../builds/rapier2d": {
             "name": "@dimforge/rapier2d",
             "dependencies": {
                 "wasm-pack": "^0.12.1"
@@ -39,8 +39,19 @@
                 "typedoc": "^0.25.13"
             }
         },
+        "../rapier2d": {
+            "name": "@dimforge/rapier2d",
+            "extraneous": true,
+            "dependencies": {
+                "wasm-pack": "^0.12.1"
+            },
+            "devDependencies": {
+                "rimraf": "^3.0.2",
+                "typedoc": "^0.25.13"
+            }
+        },
         "node_modules/@dimforge/rapier2d": {
-            "resolved": "../rapier2d",
+            "resolved": "../builds/rapier2d",
             "link": true
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -4263,11 +4274,10 @@
     },
     "dependencies": {
         "@dimforge/rapier2d": {
-            "version": "file:../rapier2d",
+            "version": "file:../builds/rapier2d",
             "requires": {
                 "rimraf": "^3.0.2",
                 "typedoc": "^0.25.13",
-                "typescript": "^5.7.2",
                 "wasm-pack": "^0.12.1"
             }
         },

--- a/testbed2d/src/Graphics.ts
+++ b/testbed2d/src/Graphics.ts
@@ -224,8 +224,8 @@ export class Graphics {
                 this.viewport.addChild(graphics);
                 break;
             default:
-                console.log("Unknown shape to render.");
-                break;
+                console.log("Unknown shape to render: ", collider.shapeType());
+                return;
         }
 
         let t = collider.translation();

--- a/testbed2d/src/demos/voxels.ts
+++ b/testbed2d/src/demos/voxels.ts
@@ -7,12 +7,12 @@ function generateVoxels(n: number) {
 
     let i;
     for (i = 0; i <= n; ++i) {
-        let y = Math.max(-0.8, Math.min(Math.sin(i / n * 10.0), 0.8)) * 8.0;
+        let y = Math.max(-0.8, Math.min(Math.sin((i / n) * 10.0), 0.8)) * 8.0;
         points.push(i - n / 2.0, y);
     }
     return {
         points: new Float32Array(points),
-        voxelSize: { x: 1.0, y: 1.2 }
+        voxelSize: {x: 1.0, y: 1.2},
     };
 }
 
@@ -47,19 +47,13 @@ export function initWorld(RAPIER: RAPIER_API, testbed: Testbed) {
             let y = j * shift + centery + 10.0;
 
             // Create dynamic cube.
-            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(
-                x,
-                y,
-            );
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(x, y);
             let body = world.createRigidBody(bodyDesc);
             let colliderDesc;
 
             switch (j % 3) {
                 case 0:
-                    colliderDesc = RAPIER.ColliderDesc.cuboid(
-                        rad,
-                        rad,
-                    );
+                    colliderDesc = RAPIER.ColliderDesc.cuboid(rad, rad);
                     break;
                 case 1:
                     colliderDesc = RAPIER.ColliderDesc.ball(rad);

--- a/testbed2d/src/demos/voxels.ts
+++ b/testbed2d/src/demos/voxels.ts
@@ -1,0 +1,96 @@
+import type {Testbed} from "../Testbed";
+
+type RAPIER_API = typeof import("@dimforge/rapier2d");
+
+function generateVoxels(n: number) {
+    let points = [];
+
+    let i;
+    for (i = 0; i <= n; ++i) {
+        let y = Math.max(-0.8, Math.min(Math.sin(i / n * 10.0), 0.8)) * 8.0;
+        points.push(i - n / 2.0, y);
+    }
+    return {
+        points: new Float32Array(points),
+        voxelSize: { x: 1.0, y: 1.2 }
+    };
+}
+
+export function initWorld(RAPIER: RAPIER_API, testbed: Testbed) {
+    let gravity = new RAPIER.Vector2(0.0, -9.81);
+    let world = new RAPIER.World(gravity);
+
+    // Create Ground.
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
+    let body = world.createRigidBody(bodyDesc);
+    let voxels = generateVoxels(100);
+    let colliderDesc = RAPIER.ColliderDesc.voxels(
+        voxels.points,
+        voxels.voxelSize,
+    );
+    world.createCollider(colliderDesc, body);
+
+    // Dynamic cubes.
+    let num = 10;
+    let numy = 4;
+    let rad = 1.0;
+
+    let shift = rad * 2.0 + rad;
+    let centery = shift / 2.0;
+
+    let offset = -num * (rad * 2.0 + rad) * 0.5;
+    let i, j;
+
+    for (j = 0; j < numy; ++j) {
+        for (i = 0; i < num; ++i) {
+            let x = i * shift + offset;
+            let y = j * shift + centery + 10.0;
+
+            // Create dynamic cube.
+            let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(
+                x,
+                y,
+            );
+            let body = world.createRigidBody(bodyDesc);
+            let colliderDesc;
+
+            switch (j % 3) {
+                case 0:
+                    colliderDesc = RAPIER.ColliderDesc.cuboid(
+                        rad,
+                        rad,
+                    );
+                    break;
+                case 1:
+                    colliderDesc = RAPIER.ColliderDesc.ball(rad);
+                    break;
+                case 2:
+                    colliderDesc = RAPIER.ColliderDesc.cuboid(
+                        rad / 2.0,
+                        rad / 2.0,
+                    );
+                    world.createCollider(colliderDesc, body);
+                    colliderDesc = RAPIER.ColliderDesc.cuboid(
+                        rad / 2.0,
+                        rad,
+                    ).setTranslation(rad, 0.0);
+                    world.createCollider(colliderDesc, body);
+                    colliderDesc = RAPIER.ColliderDesc.cuboid(
+                        rad / 2.0,
+                        rad,
+                    ).setTranslation(-rad, 0.0);
+                    break;
+            }
+
+            world.createCollider(colliderDesc, body);
+        }
+
+        offset -= 0.05 * rad * (num - 1.0);
+    }
+
+    testbed.setWorld(world);
+    testbed.lookAt({
+        target: {x: 0.0, y: 0.0},
+        zoom: 20.0,
+    });
+}

--- a/testbed2d/src/index.ts
+++ b/testbed2d/src/index.ts
@@ -9,6 +9,7 @@ import * as LockedRotations from "./demos/lockedRotations";
 import * as ConvexPolygons from "./demos/convexPolygons";
 import * as CharacterController from "./demos/characterController";
 import * as PidController from "./demos/pidController";
+import * as Voxels from "./demos/voxels";
 
 import("@dimforge/rapier2d").then((RAPIER) => {
     let builders = new Map([
@@ -22,6 +23,7 @@ import("@dimforge/rapier2d").then((RAPIER) => {
         ["locked rotations", LockedRotations.initWorld],
         ["pid controller", PidController.initWorld],
         ["polyline", Polyline.initWorld],
+        ["voxels", Voxels.initWorld],
     ]);
     let testbed = new Testbed(RAPIER, builders);
     testbed.run();

--- a/testbed3d/package-lock.json
+++ b/testbed3d/package-lock.json
@@ -9,17 +9,14 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@dimforge/rapier3d": "file:../rapier3d",
+                "@dimforge/rapier3d": "file:../builds/rapier3d",
                 "hash-wasm": "^4.12.0",
                 "lil-gui": "^0.17.0",
-                "md5": "^2.3.0",
-                "murmurhash-js": "^1.0.0",
                 "seedrandom": "^3.0.5",
                 "stats.js": "^0.17.0",
                 "three": "^0.146.0"
             },
             "devDependencies": {
-                "@types/md5": "^2.3.2",
                 "@types/seedrandom": "^3.0.2",
                 "@types/stats.js": "^0.17.0",
                 "@types/three": "^0.144.0",
@@ -32,8 +29,19 @@
                 "webpack-dev-server": "^4.11.1"
             }
         },
+        "../builds/rapier3d": {
+            "name": "@dimforge/rapier3d",
+            "dependencies": {
+                "wasm-pack": "^0.12.1"
+            },
+            "devDependencies": {
+                "rimraf": "^3.0.2",
+                "typedoc": "^0.25.13"
+            }
+        },
         "../rapier3d": {
             "name": "@dimforge/rapier3d",
+            "extraneous": true,
             "dependencies": {
                 "typescript": "^5.7.2",
                 "wasm-pack": "^0.12.1"
@@ -44,7 +52,7 @@
             }
         },
         "node_modules/@dimforge/rapier3d": {
-            "resolved": "../rapier3d",
+            "resolved": "../builds/rapier3d",
             "link": true
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -297,13 +305,6 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/md5": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.5.tgz",
-            "integrity": "sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==",
             "dev": true,
             "license": "MIT"
         },
@@ -983,15 +984,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/charenc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1223,15 +1215,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/crypt": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -2230,12 +2213,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "license": "MIT"
-        },
         "node_modules/is-core-module": {
             "version": "2.15.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
@@ -2472,17 +2449,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/md5": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "~1.1.6"
-            }
-        },
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2643,12 +2609,6 @@
             "bin": {
                 "multicast-dns": "cli.js"
             }
-        },
-        "node_modules/murmurhash-js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-            "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-            "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "0.6.4",

--- a/testbed3d/src/Graphics.ts
+++ b/testbed3d/src/Graphics.ts
@@ -486,7 +486,7 @@ export class Graphics {
                 return;
             default:
                 console.log("Unknown shape to render.");
-                break;
+                return;
         }
 
         if (!!instance) {

--- a/testbed3d/src/demos/voxels.ts
+++ b/testbed3d/src/demos/voxels.ts
@@ -1,0 +1,123 @@
+import seedrandom from "seedrandom";
+import type {Testbed} from "../Testbed";
+
+type RAPIER_API = typeof import("@dimforge/rapier3d");
+
+function generateVoxels(n: number) {
+    let points = [];
+
+    let i, j;
+    for (i = 0; i <= n; ++i) {
+        for (j = 0; j <= n; ++j) {
+            let y = Math.max(-0.8, Math.min(Math.sin(i / n * 10.0) * Math.cos(j / n * 10.0), 0.8)) * 8.0;
+            points.push(i - n / 2.0, y, j - n / 2.0);
+        }
+    }
+    return {
+        points: new Float32Array(points),
+        voxelSize: { x: 1.0, y: 1.2, z: 1.5 }
+    };
+}
+
+export function initWorld(RAPIER: RAPIER_API, testbed: Testbed) {
+    let gravity = new RAPIER.Vector3(0.0, -9.81, 0.0);
+    let world = new RAPIER.World(gravity);
+
+    // Create Ground.
+    let bodyDesc = RAPIER.RigidBodyDesc.fixed();
+    let body = world.createRigidBody(bodyDesc);
+    let voxels = generateVoxels(100);
+    let colliderDesc = RAPIER.ColliderDesc.voxels(
+        voxels.points,
+        voxels.voxelSize,
+    );
+    world.createCollider(colliderDesc, body);
+
+    // Dynamic cubes.
+    let num = 10;
+    let numy = 4;
+    let rad = 1.0;
+
+    let shift = rad * 2.0 + rad;
+    let centery = shift / 2.0;
+
+    let offset = -num * (rad * 2.0 + rad) * 0.5;
+    let i, j, k;
+
+    for (j = 0; j < numy; ++j) {
+        for (i = 0; i < num; ++i) {
+            for (k = 0; k < num; ++k) {
+                let x = i * shift + offset;
+                let y = j * shift + centery + 10.0;
+                let z = k * shift + offset;
+
+                // Create dynamic cube.
+                let bodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(
+                    x,
+                    y,
+                    z,
+                );
+                let body = world.createRigidBody(bodyDesc);
+                let colliderDesc;
+
+                switch (j % 5) {
+                    case 0:
+                        colliderDesc = RAPIER.ColliderDesc.cuboid(
+                            rad,
+                            rad,
+                            rad,
+                        );
+                        break;
+                    case 1:
+                        colliderDesc = RAPIER.ColliderDesc.ball(rad);
+                        break;
+                    case 2:
+                        colliderDesc = RAPIER.ColliderDesc.roundCylinder(
+                            rad,
+                            rad,
+                            rad / 10.0,
+                        );
+                        break;
+                    case 3:
+                        colliderDesc = RAPIER.ColliderDesc.cone(rad, rad);
+                        break;
+                    case 4:
+                        colliderDesc = RAPIER.ColliderDesc.cuboid(
+                            rad / 2.0,
+                            rad / 2.0,
+                            rad / 2.0,
+                        );
+                        world.createCollider(colliderDesc, body);
+                        colliderDesc = RAPIER.ColliderDesc.cuboid(
+                            rad / 2.0,
+                            rad,
+                            rad / 2.0,
+                        ).setTranslation(rad, 0.0, 0.0);
+                        world.createCollider(colliderDesc, body);
+                        colliderDesc = RAPIER.ColliderDesc.cuboid(
+                            rad / 2.0,
+                            rad,
+                            rad / 2.0,
+                        ).setTranslation(-rad, 0.0, 0.0);
+                        break;
+                }
+
+                world.createCollider(colliderDesc, body);
+            }
+        }
+
+        offset -= 0.05 * rad * (num - 1.0);
+    }
+
+    testbed.setWorld(world);
+
+    let cameraPosition = {
+        eye: {
+            x: -88.48024008669711,
+            y: 46.911325612198354,
+            z: 83.56055570254844,
+        },
+        target: {x: 0.0, y: 0.0, z: 0.0},
+    };
+    testbed.lookAt(cameraPosition);
+}

--- a/testbed3d/src/demos/voxels.ts
+++ b/testbed3d/src/demos/voxels.ts
@@ -9,13 +9,20 @@ function generateVoxels(n: number) {
     let i, j;
     for (i = 0; i <= n; ++i) {
         for (j = 0; j <= n; ++j) {
-            let y = Math.max(-0.8, Math.min(Math.sin(i / n * 10.0) * Math.cos(j / n * 10.0), 0.8)) * 8.0;
+            let y =
+                Math.max(
+                    -0.8,
+                    Math.min(
+                        Math.sin((i / n) * 10.0) * Math.cos((j / n) * 10.0),
+                        0.8,
+                    ),
+                ) * 8.0;
             points.push(i - n / 2.0, y, j - n / 2.0);
         }
     }
     return {
         points: new Float32Array(points),
-        voxelSize: { x: 1.0, y: 1.2, z: 1.5 }
+        voxelSize: {x: 1.0, y: 1.2, z: 1.5},
     };
 }
 

--- a/testbed3d/src/index.ts
+++ b/testbed3d/src/index.ts
@@ -1,5 +1,6 @@
 import {Testbed} from "./Testbed";
 import * as Trimesh from "./demos/trimesh";
+import * as Voxels from "./demos/voxels";
 import * as CollisionGroups from "./demos/collisionGroups";
 import * as Pyramid from "./demos/pyramid";
 import * as Keva from "./demos/keva";
@@ -32,6 +33,7 @@ import("@dimforge/rapier3d").then((RAPIER) => {
         ["platform", Platform.initWorld],
         ["pyramid", Pyramid.initWorld],
         ["triangle mesh", Trimesh.initWorld],
+        ["voxels", Voxels.initWorld],
         ["GLTF to convexHull", glbToConvexHull.initWorld],
         ["GLTF to trimesh", glbToTrimesh.initWorld],
     ]);


### PR DESCRIPTION
This PRs adds partial support of a new dedicated shape for colliders made of voxels. This shape type is designed to handle efficiently, and without "internal edges" artifacts, collision detection with objects defined as a set of voxels. Each `Voxels` shape is free to have their own voxel size; and can be rotated/translated arbitrarily as a whole. The voxel size can be different along each axis (i.e. it can be a rectangle instead of just a cube).

This feature is still experimental as it is missing some elements. The following is supported:
- Ray-casting.
- Point-projection (very unoptimized).
- Contact-manifold generation with convex shapes.
- Conversion from and to meshes/polylines.
- Conversion to outlines for debug-rendering.
- Dynamic addition or removal of individual voxels.

Notable features that are currently missing are:
- Collision-detection with non-convex shapes (or compound shapes).
- Shape-casting.

<img width="1648" alt="image" src="https://github.com/user-attachments/assets/fd2517dd-28df-43bd-bc9f-8715d6ea2fbd" />
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/8a79f22e-16f6-49f7-a933-44a59b2c81da" />