### PR TITLE
feat: add support for shape-casting and ccd on voxels collider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.16.1 (2 May 2025)
+
+### Added
+
+- Added `Collider.clearShapeCache` to release the reference to the JS shape stored in the collider, oor too force its
+  recomputation the next time the collider shape is accessed.
+- Added support for shape-casting involving Voxels colliders.
+- Added support for CCD involving Voxels colliders.
+
 ### 0.16.0 (24 April 2025)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-deterministic"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-simd"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-deterministic"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-simd"
-version = "0.15.1"
+version = "0.16.1"
 dependencies = [
  "bincode",
  "js-sys",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bcca0d91ccd7a49aec62565bcfc8dae9fd449e7fda420d51a2da84f8d86bda0"
+checksum = "c99fdeb6d95e0658d23fba6edac15e1ff5e4a64b656a8a7c159f9e8b8528830e"
 dependencies = [
  "approx",
  "arrayvec",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a8e71e0a9e6d648dce948bdd95568c7f5ccf2ce2d19908ef5a68c9bf550972"
+checksum = "3d53371b66dd245b2aed7ad49e97596f3b1cf8c4ef4d11590fbc8f4a3b6d0270"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "rapier2d"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfd38bab4c05990316884af854aa7b79e38386c8aa9a19c3bafb3718395aa8c"
+checksum = "5ec6acdc5db3699c64e000945450c844d34b215dae3bf875b40e20b1909c0063"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5880578346b99f4d0f449f1daca5cd66f5ac72ad22606b021a6b8507d75782a"
+checksum = "a35ec3d01c4f918675411442024a1fbfb7eafdd878a6e82479ff6e461a9092fc"
 dependencies = [
  "approx",
  "arrayvec",

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.25.0", features = [
+rapier{{ dimension }}d = { version = "0.25.1", features = [
     "serde-serialize",
     "debug-render",
     {%- for feature in additional_features %}

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -148,6 +148,18 @@ export class Collider {
     }
 
     /**
+     * Set the internal cached JS shape to null.
+     *
+     * This can be useful if you want to free some memory (assuming you are not
+     * holding any other references to the shape object), or in order to force
+     * the recalculation of the JS shape (the next time the `shape` getter is
+     * accessed) from the WASM source of truth.
+     */
+    public clearShapeCache() {
+        this._shape = null;
+    }
+
+    /**
      * Checks if this collider is still valid (i.e. that it has
      * not been deleted from the collider set yet).
      */

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -362,13 +362,7 @@ impl RawColliderSet {
     }
 
     #[cfg(feature = "dim2")]
-    pub fn coSetVoxel(
-        &mut self,
-        handle: FlatHandle,
-        ix: i32,
-        iy: i32,
-        filled: bool,
-    ) {
+    pub fn coSetVoxel(&mut self, handle: FlatHandle, ix: i32, iy: i32, filled: bool) {
         self.map_mut(handle, |co| {
             if let Some(vox) = co.shape_mut().as_voxels_mut() {
                 vox.set_voxel(Point::new(ix, iy), filled);
@@ -377,14 +371,7 @@ impl RawColliderSet {
     }
 
     #[cfg(feature = "dim3")]
-    pub fn coSetVoxel(
-        &mut self,
-        handle: FlatHandle,
-        ix: i32,
-        iy: i32,
-        iz: i32,
-        filled: bool,
-    ) {
+    pub fn coSetVoxel(&mut self, handle: FlatHandle, ix: i32, iy: i32, iz: i32, filled: bool) {
         self.map_mut(handle, |co| {
             if let Some(vox) = co.shape_mut().as_voxels_mut() {
                 vox.set_voxel(Point::new(ix, iy, iz), filled);

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -336,8 +336,8 @@ impl RawColliderSet {
         self.map(handle, |co| {
             let vox = co.shape().as_voxels()?;
             let coords = vox
-                .centers()
-                .filter_map(|(id, _, state)| (!state.is_empty()).then_some(vox.voxel_key_at(id)))
+                .voxels()
+                .filter_map(|vox| (!vox.state.is_empty()).then_some(vox.grid_coords))
                 .flat_map(|ids| ids.coords.data.0[0])
                 .collect();
             Some(coords)
@@ -371,7 +371,7 @@ impl RawColliderSet {
     ) {
         self.map_mut(handle, |co| {
             if let Some(vox) = co.shape_mut().as_voxels_mut() {
-                vox.insert_voxel_at_key(Point::new(ix, iy), filled);
+                vox.set_voxel(Point::new(ix, iy), filled);
             }
         })
     }
@@ -387,7 +387,7 @@ impl RawColliderSet {
     ) {
         self.map_mut(handle, |co| {
             if let Some(vox) = co.shape_mut().as_voxels_mut() {
-                vox.insert_voxel_at_key(Point::new(ix, iy, iz), filled);
+                vox.set_voxel(Point::new(ix, iy, iz), filled);
             }
         })
     }

--- a/testbed2d/src/Graphics.ts
+++ b/testbed2d/src/Graphics.ts
@@ -223,6 +223,28 @@ export class Graphics {
 
                 this.viewport.addChild(graphics);
                 break;
+            case RAPIER.ShapeType.Voxels:
+                graphics = new PIXI.Graphics();
+                graphics.beginFill(this.colorPalette[instanceId], 1.0);
+                collider.clearShapeCache();
+                let shape = collider.shape as RAPIER.Voxels;
+                let gridCoords = shape.data;
+                let sz = shape.voxelSize;
+
+                for (i = 0; i < gridCoords.length; i += 2) {
+                    let minx = gridCoords[i] * sz.x;
+                    let miny = gridCoords[i + 1] * sz.y;
+                    let maxx = minx + sz.x;
+                    let maxy = miny + sz.y;
+
+                    graphics.moveTo(minx, -miny);
+                    graphics.lineTo(maxx, -miny);
+                    graphics.lineTo(maxx, -maxy);
+                    graphics.lineTo(minx, -maxy);
+                }
+
+                this.viewport.addChild(graphics);
+                break;
             default:
                 console.log("Unknown shape to render: ", collider.shapeType());
                 return;

--- a/testbed3d/src/Graphics.ts
+++ b/testbed3d/src/Graphics.ts
@@ -68,8 +68,8 @@ function genVoxelsGeometry(collider: RAPIER.Collider) {
 
     return {
         vertices: new Float32Array(vertices),
-        indices: new Uint32Array(indices)
-    }
+        indices: new Uint32Array(indices),
+    };
 }
 
 function genHeightfieldGeometry(collider: RAPIER.Collider) {


### PR DESCRIPTION
### 0.16.1 (2 May 2025)

### Added

- Added `Collider.clearShapeCache` to release the reference to the JS shape stored in the collider, oor too force its
  recomputation the next time the collider shape is accessed.
- Added support for shape-casting involving Voxels colliders.
- Added support for CCD involving Voxels colliders.