### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
+### 0.17.0 (16 May 2025)
+
+#### Fixed
+
+- Fix sensor events not triggering when hitting a voxels collider.
+
+#### Added
+
+- Added support for voxels colliders attached to dynamic rigid-bodies.
+- Added force calculation between colliding voxels/voxels and voxels/compound shapes.
+
 ### 0.16.2 (5 May 2025)
 
-### Fixed
+#### Fixed
 
 - Fixed infinite loop in `collider.setVoxel`.
 
 ### 0.16.1 (2 May 2025)
 
-### Added
+#### Added
 
 - Added `Collider.clearShapeCache` to release the reference to the JS shape stored in the collider, oor too force its
   recomputation the next time the collider shape is accessed.
@@ -15,7 +26,7 @@
 
 ### 0.16.0 (24 April 2025)
 
-### Added
+#### Added
 
 - Added `ColliderDesc.voxels` to create a collider with a shape optimized for voxels.
 - Added `Collider.setVoxel` for adding or removing a voxel from a collider with a voxel shape.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-deterministic"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-simd"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-deterministic"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-simd"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "js-sys",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b89f8a3309b82a3a81a6957c7916fe00834e79678451683b048e8d75109b9e4"
+checksum = "e42bcde4f79b1a4979cfd197ff88b488fe4419d9fdc4596ec1bd322f9dde873f"
 dependencies = [
  "approx",
  "arrayvec",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec55ce6f725367f8149f750575e79a8879d71b7257c02273259f9375822821f"
+checksum = "9afd82705dbb85fa37be7fd2e27042cc913b97ca116bc0205e522ed30d5c25a7"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "rapier2d"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec6acdc5db3699c64e000945450c844d34b215dae3bf875b40e20b1909c0063"
+checksum = "5a9f1b88f5e0ae8d362754c217563fddcf53126a808851e0209f3d9eb8f7c661"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35ec3d01c4f918675411442024a1fbfb7eafdd878a6e82479ff6e461a9092fc"
+checksum = "6cba962ac4bea788ed402278ea7696d88a4eb507839e2b1ac1015632e5803ab6"
 dependencies = [
  "approx",
  "arrayvec",

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.25.1", features = [
+rapier{{ dimension }}d = { version = "0.26.0", features = [
     "serde-serialize",
     "debug-render",
     {%- for feature in additional_features %}

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -1,4 +1,4 @@
-import {RawColliderSet, RawVoxelPrimitiveGeometry} from "../raw";
+import {RawColliderSet} from "../raw";
 import {Rotation, RotationOps, Vector, VectorOps} from "../math";
 import {
     CoefficientCombineRule,
@@ -1288,19 +1288,12 @@ export class ColliderDesc {
      *               point is defined from 3 (resp 2) contiguous numbers per point
      *               in 3D (resp 2D).
      * @param voxelSize - The size of each voxel.
-     *                    If the `primitiveGeometry` is `PseudoBall`, then only the first component
-     *                    will be taken into account. If it is `PseudoCube` then every component of
-     *                    the size vector are taken into account, defining the size along each
-     *                    local coordinate axis.
-     * @param primitiveGeometry - (optional) Indicates the geometric shape of
-     *                            each voxel. Defaults to cuboid shapes.
      */
     public static voxels(
         voxels: Float32Array | Int32Array,
         voxelSize: Vector,
-        primitiveGeometry?: RawVoxelPrimitiveGeometry,
     ): ColliderDesc {
-        const shape = new Voxels(voxels, voxelSize, primitiveGeometry);
+        const shape = new Voxels(voxels, voxelSize);
         return new ColliderDesc(shape);
     }
 

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -1,7 +1,7 @@
 use crate::geometry::shape::SharedShapeUtility;
 use crate::geometry::{
     RawColliderSet, RawColliderShapeCastHit, RawPointProjection, RawRayIntersection, RawShape,
-    RawShapeCastHit, RawShapeContact, RawShapeType, RawVoxelPrimitiveGeometry,
+    RawShapeCastHit, RawShapeContact, RawShapeType,
 };
 use crate::math::{RawRotation, RawVector};
 use crate::utils::{self, FlatHandle};
@@ -341,16 +341,6 @@ impl RawColliderSet {
                 .flat_map(|ids| ids.coords.data.0[0])
                 .collect();
             Some(coords)
-        })
-    }
-
-    pub fn coVoxelPrimitiveGeometry(
-        &self,
-        handle: FlatHandle,
-    ) -> Option<RawVoxelPrimitiveGeometry> {
-        self.map(handle, |co| {
-            let vox = co.shape().as_voxels()?;
-            Some(vox.primitive_geometry().into())
         })
     }
 

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -5,36 +5,11 @@ use na::DMatrix;
 #[cfg(feature = "dim2")]
 use na::DVector;
 use na::Unit;
-use rapier::geometry::{Shape, SharedShape, TriMeshFlags, VoxelPrimitiveGeometry};
+use rapier::geometry::{Shape, SharedShape, TriMeshFlags};
 use rapier::math::{Isometry, Point, Real, Vector, DIM};
 use rapier::parry::query;
 use rapier::parry::query::{Ray, ShapeCastOptions};
 use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-#[derive(Copy, Clone)]
-pub enum RawVoxelPrimitiveGeometry {
-    PseudoBall,
-    PseudoCube,
-}
-
-impl Into<VoxelPrimitiveGeometry> for RawVoxelPrimitiveGeometry {
-    fn into(self) -> VoxelPrimitiveGeometry {
-        match self {
-            RawVoxelPrimitiveGeometry::PseudoBall => VoxelPrimitiveGeometry::PseudoBall,
-            RawVoxelPrimitiveGeometry::PseudoCube => VoxelPrimitiveGeometry::PseudoCube,
-        }
-    }
-}
-
-impl Into<RawVoxelPrimitiveGeometry> for VoxelPrimitiveGeometry {
-    fn into(self) -> RawVoxelPrimitiveGeometry {
-        match self {
-            VoxelPrimitiveGeometry::PseudoBall => RawVoxelPrimitiveGeometry::PseudoBall,
-            VoxelPrimitiveGeometry::PseudoCube => RawVoxelPrimitiveGeometry::PseudoCube,
-        }
-    }
-}
 
 pub trait SharedShapeUtility {
     fn castShape(
@@ -313,7 +288,6 @@ impl RawShape {
     }
 
     pub fn voxels(
-        primitive_geometry: RawVoxelPrimitiveGeometry,
         voxel_size: &RawVector,
         grid_coords: Vec<i32>,
     ) -> Self {
@@ -322,20 +296,17 @@ impl RawShape {
             .map(Point::from_slice)
             .collect();
         Self(SharedShape::voxels(
-            primitive_geometry.into(),
             voxel_size.0,
             &grid_coords,
         ))
     }
 
     pub fn voxelsFromPoints(
-        primitive_geometry: RawVoxelPrimitiveGeometry,
         voxel_size: &RawVector,
         points: Vec<f32>,
     ) -> Self {
         let points: Vec<_> = points.chunks_exact(DIM).map(Point::from_slice).collect();
         Self(SharedShape::voxels_from_points(
-            primitive_geometry.into(),
             voxel_size.0,
             &points,
         ))


### PR DESCRIPTION
### 0.17.0 (16 May 2025)

#### Fixed

- Fix sensor events not triggering when hitting a voxels collider.

#### Added

- Added support for voxels colliders attached to dynamic rigid-bodies.
- Added force calculation between colliding voxels/voxels and voxels/compound shapes.