### PR TITLE
Release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.17.1 (23 May 2025)
+
+#### Added
+
+- Added optional arguments to `World.debugRender(filterFlags, filterPredicate)` to prevent some colliders from being
+  rendered.
+- Added `Collider.combineVoxelStates` to ensure two adjacent voxels colliders don’t suffer from the internal edges
+  problem, and `Collider.propagateVoxelChange` to maintain that coupling after modifications with `.setVoxel`.
+
 ### 0.17.0 (16 May 2025)
 
 #### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bcde4f79b1a4979cfd197ff88b488fe4419d9fdc4596ec1bd322f9dde873f"
+checksum = "fcc75102c1fac2294401262c78e5a42abe7168244c9436df2fec8fe0c27395c7"
 dependencies = [
  "approx",
  "arrayvec",
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afd82705dbb85fa37be7fd2e27042cc913b97ca116bc0205e522ed30d5c25a7"
+checksum = "e7f8d0a3b2f4c0e250d4599b69e490535521c3497e2b88b0b5d2ada251bc83a8"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "rapier2d"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9f1b88f5e0ae8d362754c217563fddcf53126a808851e0209f3d9eb8f7c661"
+checksum = "b70793351467e663d06f52ffdf6138a1d7920b305ee4b7751e1adb90d56a797f"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "rapier3d"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cba962ac4bea788ed402278ea7696d88a4eb507839e2b1ac1015632e5803ab6"
+checksum = "7f1015500058823ba9c479c908d7069adcf3f0f51a3e49dca7efc5575df7e574"
 dependencies = [
  "approx",
  "arrayvec",

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.26.0", features = [
+rapier{{ dimension }}d = { version = "0.26.1", features = [
     "serde-serialize",
     "debug-render",
     {%- for feature in additional_features %}

--- a/src.ts/pipeline/debug_render_pipeline.ts
+++ b/src.ts/pipeline/debug_render_pipeline.ts
@@ -7,7 +7,8 @@ import {
     MultibodyJointSet,
     RigidBodySet,
 } from "../dynamics";
-import {BroadPhase, ColliderSet, NarrowPhase} from "../geometry";
+import {BroadPhase, Collider, ColliderSet, NarrowPhase} from "../geometry";
+import {QueryFilterFlags} from "./query_pipeline";
 
 /**
  * The vertex and color buffers for debug-redering the physics scene.
@@ -66,6 +67,8 @@ export class DebugRenderPipeline {
         impulse_joints: ImpulseJointSet,
         multibody_joints: MultibodyJointSet,
         narrow_phase: NarrowPhase,
+        filterFlags?: QueryFilterFlags,
+        filterPredicate?: (collider: Collider) => boolean,
     ) {
         this.raw.render(
             bodies.raw,
@@ -73,6 +76,8 @@ export class DebugRenderPipeline {
             impulse_joints.raw,
             multibody_joints.raw,
             narrow_phase.raw,
+            filterFlags,
+            colliders.castClosure(filterPredicate),
         );
         this.vertices = this.raw.vertices();
         this.colors = this.raw.colors();

--- a/src.ts/pipeline/world.ts
+++ b/src.ts/pipeline/world.ts
@@ -239,14 +239,23 @@ export class World {
 
     /**
      * Computes all the lines (and their colors) needed to render the scene.
+     *
+     * @param filterFlags - Flags for excluding whole subsets of colliders from rendering.
+     * @param filterPredicate - Any collider for which this closure returns `false` will be excluded from the
+     *                          debug rendering.
      */
-    public debugRender(): DebugRenderBuffers {
+    public debugRender(
+        filterFlags?: QueryFilterFlags,
+        filterPredicate?: (collider: Collider) => boolean,
+    ): DebugRenderBuffers {
         this.debugRenderPipeline.render(
             this.bodies,
             this.colliders,
             this.impulseJoints,
             this.multibodyJoints,
             this.narrowPhase,
+            filterFlags,
+            filterPredicate,
         );
         return new DebugRenderBuffers(
             this.debugRenderPipeline.vertices,

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -369,6 +369,101 @@ impl RawColliderSet {
         })
     }
 
+    #[cfg(feature = "dim2")]
+    pub fn coPropagateVoxelChange(
+        &mut self,
+        handle1: FlatHandle,
+        handle2: FlatHandle,
+        ix: i32,
+        iy: i32,
+        shift_x: i32,
+        shift_y: i32,
+    ) {
+        self.map_pair_mut(handle1, handle2, |co1, co2| {
+            if let (Some(co1), Some(co2)) = (co1, co2) {
+                if let (Some(vox1), Some(vox2)) = (
+                    co1.shape_mut().as_voxels_mut(),
+                    co2.shape_mut().as_voxels_mut(),
+                ) {
+                    vox1.propagate_voxel_change(
+                        vox2,
+                        Point::new(ix, iy),
+                        Vector::new(shift_x, shift_y),
+                    );
+                }
+            }
+        })
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn coPropagateVoxelChange(
+        &mut self,
+        handle1: FlatHandle,
+        handle2: FlatHandle,
+        ix: i32,
+        iy: i32,
+        iz: i32,
+        shift_x: i32,
+        shift_y: i32,
+        shift_z: i32,
+    ) {
+        self.map_pair_mut(handle1, handle2, |co1, co2| {
+            if let (Some(co1), Some(co2)) = (co1, co2) {
+                if let (Some(vox1), Some(vox2)) = (
+                    co1.shape_mut().as_voxels_mut(),
+                    co2.shape_mut().as_voxels_mut(),
+                ) {
+                    vox1.propagate_voxel_change(
+                        vox2,
+                        Point::new(ix, iy, iz),
+                        Vector::new(shift_x, shift_y, shift_z),
+                    );
+                }
+            }
+        })
+    }
+
+    #[cfg(feature = "dim2")]
+    pub fn coCombineVoxelStates(
+        &mut self,
+        handle1: FlatHandle,
+        handle2: FlatHandle,
+        shift_x: i32,
+        shift_y: i32,
+    ) {
+        self.map_pair_mut(handle1, handle2, |co1, co2| {
+            if let (Some(co1), Some(co2)) = (co1, co2) {
+                if let (Some(vox1), Some(vox2)) = (
+                    co1.shape_mut().as_voxels_mut(),
+                    co2.shape_mut().as_voxels_mut(),
+                ) {
+                    vox1.combine_voxel_states(vox2, Vector::new(shift_x, shift_y));
+                }
+            }
+        })
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn coCombineVoxelStates(
+        &mut self,
+        handle1: FlatHandle,
+        handle2: FlatHandle,
+        shift_x: i32,
+        shift_y: i32,
+        shift_z: i32,
+    ) {
+        self.map_pair_mut(handle1, handle2, |co1, co2| {
+            if let (Some(co1), Some(co2)) = (co1, co2) {
+                if let (Some(vox1), Some(vox2)) = (
+                    co1.shape_mut().as_voxels_mut(),
+                    co2.shape_mut().as_voxels_mut(),
+                ) {
+                    vox1.combine_voxel_states(vox2, Vector::new(shift_x, shift_y, shift_z));
+                }
+            }
+        })
+    }
+
     /// The vertices of this triangle mesh, polyline, convex polyhedron, segment, triangle or convex polyhedron, if it is one.
     pub fn coVertices(&self, handle: FlatHandle) -> Option<Vec<f32>> {
         let flatten =

--- a/src/geometry/collider_set.rs
+++ b/src/geometry/collider_set.rs
@@ -35,6 +35,19 @@ impl RawColliderSet {
             .expect("Invalid Collider reference. It may have been removed from the physics World.");
         f(collider)
     }
+
+    pub(crate) fn map_pair_mut<T>(
+        &mut self,
+        handle1: FlatHandle,
+        handle2: FlatHandle,
+        f: impl FnOnce(Option<&mut Collider>, Option<&mut Collider>) -> T,
+    ) -> T {
+        let (collider1, collider2) = self.0.get_pair_mut(
+            utils::collider_handle(handle1),
+            utils::collider_handle(handle2),
+        );
+        f(collider1, collider2)
+    }
 }
 
 impl RawColliderSet {

--- a/src/geometry/shape.rs
+++ b/src/geometry/shape.rs
@@ -287,29 +287,17 @@ impl RawShape {
         Self(SharedShape::round_cone(halfHeight, radius, borderRadius))
     }
 
-    pub fn voxels(
-        voxel_size: &RawVector,
-        grid_coords: Vec<i32>,
-    ) -> Self {
+    pub fn voxels(voxel_size: &RawVector, grid_coords: Vec<i32>) -> Self {
         let grid_coords: Vec<_> = grid_coords
             .chunks_exact(DIM)
             .map(Point::from_slice)
             .collect();
-        Self(SharedShape::voxels(
-            voxel_size.0,
-            &grid_coords,
-        ))
+        Self(SharedShape::voxels(voxel_size.0, &grid_coords))
     }
 
-    pub fn voxelsFromPoints(
-        voxel_size: &RawVector,
-        points: Vec<f32>,
-    ) -> Self {
+    pub fn voxelsFromPoints(voxel_size: &RawVector, points: Vec<f32>) -> Self {
         let points: Vec<_> = points.chunks_exact(DIM).map(Point::from_slice).collect();
-        Self(SharedShape::voxels_from_points(
-            voxel_size.0,
-            &points,
-        ))
+        Self(SharedShape::voxels_from_points(voxel_size.0, &points))
     }
 
     pub fn polyline(vertices: Vec<f32>, indices: Vec<u32>) -> Self {

--- a/src/pipeline/debug_render_pipeline.rs
+++ b/src/pipeline/debug_render_pipeline.rs
@@ -4,8 +4,11 @@ use js_sys::Float32Array;
 use palette::convert::IntoColorUnclamped;
 use palette::rgb::Rgba;
 use palette::Hsla;
+use rapier::dynamics::{RigidBody, RigidBodySet};
+use rapier::geometry::ColliderSet;
 use rapier::math::{Point, Real};
 use rapier::pipeline::{DebugRenderBackend, DebugRenderObject, DebugRenderPipeline};
+use rapier::prelude::{QueryFilter, QueryFilterFlags};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -45,31 +48,87 @@ impl RawDebugRenderPipeline {
         impulse_joints: &RawImpulseJointSet,
         multibody_joints: &RawMultibodyJointSet,
         narrow_phase: &RawNarrowPhase,
+        filter_flags: u32,
+        filter_predicate: &js_sys::Function,
     ) {
         self.vertices.clear();
         self.colors.clear();
-        let mut backend = CopyToBuffersBackend {
-            vertices: &mut self.vertices,
-            colors: &mut self.colors,
-        };
 
-        self.raw.render(
-            &mut backend,
-            &bodies.0,
-            &colliders.0,
-            &impulse_joints.0,
-            &multibody_joints.0,
-            &narrow_phase.0,
-        )
+        crate::utils::with_filter(filter_predicate, |predicate| {
+            let mut backend = CopyToBuffersBackend {
+                filter: QueryFilter {
+                    flags: QueryFilterFlags::from_bits(filter_flags)
+                        .unwrap_or(QueryFilterFlags::empty()),
+                    groups: None,
+                    exclude_collider: None,
+                    exclude_rigid_body: None,
+                    predicate,
+                },
+                bodies: &bodies.0,
+                colliders: &colliders.0,
+                vertices: &mut self.vertices,
+                colors: &mut self.colors,
+            };
+
+            self.raw.render(
+                &mut backend,
+                &bodies.0,
+                &colliders.0,
+                &impulse_joints.0,
+                &multibody_joints.0,
+                &narrow_phase.0,
+            )
+        })
     }
 }
 
 struct CopyToBuffersBackend<'a> {
+    filter: QueryFilter<'a>,
+    bodies: &'a RigidBodySet,
+    colliders: &'a ColliderSet,
     vertices: &'a mut Vec<f32>,
     colors: &'a mut Vec<f32>,
 }
 
 impl<'a> DebugRenderBackend for CopyToBuffersBackend<'a> {
+    fn filter_object(&self, object: DebugRenderObject) -> bool {
+        let test_rigid_body = |rb: &RigidBody| {
+            rb.colliders().iter().all(|handle| {
+                let Some(co) = self.colliders.get(*handle) else {
+                    return false;
+                };
+                self.filter.test(self.bodies, *handle, co)
+            })
+        };
+
+        match object {
+            DebugRenderObject::Collider(handle, co)
+            | DebugRenderObject::ColliderAabb(handle, co, _) => {
+                self.filter.test(self.bodies, handle, co)
+            }
+            DebugRenderObject::ContactPair(pair, co1, co2) => {
+                self.filter.test(self.bodies, pair.collider1, co1)
+                    && self.filter.test(self.bodies, pair.collider2, co2)
+            }
+            DebugRenderObject::ImpulseJoint(_, joint) => {
+                let Some(rb1) = self.bodies.get(joint.body1) else {
+                    return false;
+                };
+                let Some(rb2) = self.bodies.get(joint.body2) else {
+                    return false;
+                };
+                test_rigid_body(rb1) && test_rigid_body(rb2)
+            }
+            DebugRenderObject::MultibodyJoint(_, _, link) => {
+                let Some(rb) = self.bodies.get(link.rigid_body_handle()) else {
+                    return false;
+                };
+                test_rigid_body(rb)
+            }
+            DebugRenderObject::RigidBody(_, rb) => test_rigid_body(rb),
+        }
+    }
+
     /// Draws a colored line.
     ///
     /// Note that this method can be called multiple time for the same `object`.


### PR DESCRIPTION
### 0.17.1 (23 May 2025)

#### Added

- Added optional arguments to `World.debugRender(filterFlags, filterPredicate)` to prevent some colliders from being
  rendered.
- Added `Collider.combineVoxelStates` to ensure two adjacent voxels colliders don’t suffer from the internal edges
  problem, and `Collider.propagateVoxelChange` to maintain that coupling after modifications with `.setVoxel`.