### PR TITLE
feat: add reserveMemory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.17.2 (30 May 2025)
+
+#### Added
+
+- Added the function `RAPIER.reserveMemory` to instruct the internal allocator to pre-allocate more memory in preparation
+  for future operations. This typically called only once after initializing the WASM module.
+
 ### 0.17.1 (23 May 2025)
 
 #### Added

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -47,7 +47,9 @@ palette = "0.7"
 wasm-opt = [
     '-O4',
     '--dce',
+    # The two options below are needed because of: https://github.com/rustwasm/wasm-pack/issues/1501
     '--enable-bulk-memory',
+    '--enable-nontrapping-float-to-int',
     {%- for flag in additional_wasm_opt_flags %}
     '{{ flag }}',
     {%- endfor %}

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -47,6 +47,7 @@ palette = "0.7"
 wasm-opt = [
     '-O4',
     '--dce',
+    '--enable-bulk-memory',
     {%- for flag in additional_wasm_opt_flags %}
     '{{ flag }}',
     {%- endfor %}

--- a/src.ts/exports.ts
+++ b/src.ts/exports.ts
@@ -1,7 +1,22 @@
-import {version as vers} from "./raw";
+import {version as vers, reserve_memory as reserve} from "./raw";
 
 export function version(): string {
     return vers();
+}
+
+/// Reserves additional memory in WASM land.
+///
+/// This will grow the internal WASM memory buffer so that it can fit at least
+/// the specified amount of extra bytes. This can help reduce future runtime
+/// overhead due to dynamic internal memory growth once the limit of the
+/// pre-allocated memory is reached.
+///
+/// This feature is still experimental. Due to the nature of the internal
+/// allocator, there can be situations where the allocator decides to perform
+/// additional internal memory growth even though not all `extraBytesCount`
+/// are occupied yet.
+export function reserveMemory(extraBytesCount: number) {
+    reserve(extraBytesCount);
 }
 
 export * from "./math";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,13 @@ pub fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub fn reserve_memory(extra_bytes_count: u32) {
+    let mut unused: Vec<u8> = vec![];
+    unused.reserve(extra_bytes_count as usize);
+    std::hint::black_box(&unused);
+}
+
 pub mod control;
 pub mod dynamics;
 pub mod geometry;


### PR DESCRIPTION
### 0.17.2 (30 May 2025)

#### Added

- Added the function `RAPIER.reserveMemory` to instruct the internal allocator to pre-allocate more memory in preparation
  for future operations. This typically called only once after initializing the WASM module.