### PR TITLE
Fix unreachable code after return statement

### DIFF
--- a/src.ts/control/character_controller.ts
+++ b/src.ts/control/character_controller.ts
@@ -1,4 +1,8 @@
-import {RawKinematicCharacterController, RawCharacterCollision, RawVector} from "../raw";
+import {
+    RawKinematicCharacterController,
+    RawCharacterCollision,
+    RawVector,
+} from "../raw";
 import {Rotation, Vector, VectorOps} from "../math";
 import {Collider, ColliderSet, InteractionGroups, Shape} from "../geometry";
 import {QueryFilterFlags, QueryPipeline, World} from "../pipeline";


### PR DESCRIPTION
This fix makes sure `rawVect.free();` is run after the return statement.