### PR TITLE
Add exports config to help commonjs with nodenext

### DIFF
--- a/rapier-compat/rollup.config.js
+++ b/rapier-compat/rollup.config.js
@@ -37,6 +37,12 @@ const config = (dim, features_postfix) => ({
                         config.types = "rapier.d.ts";
                         config.main = "rapier.cjs";
                         config.module = "rapier.mjs";
+                        config.exports = {
+                            ".": {
+                                require: "./rapier.cjs",
+                                import: "./rapier.mjs",
+                            },
+                        };
                         // delete config.module;
                         config.files = ["*"];
                         return JSON.stringify(config, undefined, 2);


### PR DESCRIPTION
- Follow up to https://github.com/dimforge/rapier.js/pull/334#issuecomment-3155512697
- Fix #332

I tested this with https://github.com/Vrixyz/rapierjs-no-bundler/tree/main/with_npm and https://github.com/mattvb91/rapierjs-module-bug/tree/master.