### PR TITLE
Release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.18.1 (8 August 2025)
+
+### Modified
+
+- Update to Rapier 0.28.0 which includes performance improvements when CCD is active and when
+  the user applies modification to a collider or rigid-body.
+
+### Fix
+
+- Another attempt to fix bundlerless module import with rapier-compat.
+
 ### 0.18.0 (24 July 2025)
 
 ### Added
@@ -15,7 +26,7 @@
 
 #### Modified
 
-- Update to Rapier 0.22.0-beta.1 which includes a fully reworked broad-phase tha supports scene queries.
+- Update to Rapier 0.27.0-beta.1 which includes a fully reworked broad-phase tha supports scene queries.
   This implies a performance gain on large scenes by avoiding the need to re-build the underlying acceleration
   structure at each frame.
 - Un-deprecate methods for reading shape properties (for example `collider.radius()`). It turned out that these

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.27.0", features = [
+rapier{{ dimension }}d = { version = "0.28.0", features = [
     "serde-serialize",
     "debug-render",
     "profiler",
@@ -38,7 +38,7 @@ rapier{{ dimension }}d = { version = "0.27.0", features = [
 ref-cast = "1"
 wasm-bindgen = "0.2.100"
 js-sys = "0.3"
-nalgebra = "0.33"
+nalgebra = "0.34"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
 palette = "0.7"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"


### PR DESCRIPTION
### 0.18.1 (8 August 2025)

### Modified

- Update to Rapier 0.28.0 which includes performance improvements when CCD is active and when
  the user applies modification to a collider or rigid-body.

### Fix

- Another attempt to fix bundlerless module import with rapier-compat.