### PR TITLE
Release v0.19.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.19.1 (03 Oct. 2025)
+
+### Modified
+
+- Update to Rapier 0.30.0. The only change is a [switch to a sparse storage](https://github.com/dimforge/parry/pull/380)
+  for the Voxels shapes. This allows support for orders of magnitudes larger maps without reaching the 4GB WASM memory
+  limit.
+
 ### 0.19.0 (05 Sept. 2025)
 
 ### Modified

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -1,6 +1,6 @@
 [package]
 name = "dimforge_{{ js_package_name }}" # Can't be named rapier{{ dimension }}d which conflicts with the dependency.
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Sébastien Crozet <developer@crozet.re>"]
 description = "{{ dimension }}-dimensional physics engine in Rust - official JS bindings."
 documentation = "https://rapier.rs/rustdoc/rapier{{ dimension }}d/index.html"

--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -27,7 +27,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [dependencies]
-rapier{{ dimension }}d = { version = "0.29.0", features = [
+rapier{{ dimension }}d = { version = "0.30.0", features = [
     "serde-serialize",
     "debug-render",
     "profiler",


### PR DESCRIPTION
### 0.19.1 (03 Oct. 2025)

### Modified

- Update to Rapier 0.30.0. The only change is a [switch to a sparse storage](https://github.com/dimforge/parry/pull/380) for the Voxels shapes. This allows support for orders of magnitudes larger maps without reaching the 4GB WASM memory limit.