### PR TITLE
refactor: use # for private methods to reduce the minified file size

### DIFF
--- a/src.ts/coarena.ts
+++ b/src.ts/coarena.ts
@@ -12,7 +12,7 @@ export class Coarena<T> {
     }
 
     public set(handle: number, data: T) {
-        let i = this.index(handle);
+        let i = this.#index(handle);
         while (this.data.length <= i) {
             this.data.push(null);
         }
@@ -26,7 +26,7 @@ export class Coarena<T> {
     }
 
     public delete(handle: number) {
-        let i = this.index(handle);
+        let i = this.#index(handle);
         if (i < this.data.length) {
             if (this.data[i] != null) this.size -= 1;
             this.data[i] = null;
@@ -38,7 +38,7 @@ export class Coarena<T> {
     }
 
     public get(handle: number): T | null {
-        let i = this.index(handle);
+        let i = this.#index(handle);
         if (i < this.data.length) {
             return this.data[i];
         } else {
@@ -56,7 +56,7 @@ export class Coarena<T> {
         return this.data.filter((elt) => elt != null);
     }
 
-    private index(handle: number): number {
+    #index(handle: number): number {
         /// Extracts the index part of a handle (the lower 32 bits).
         /// This is done by first injecting the handle into an Float64Array
         /// which is itself injected into an Uint32Array (at construction time).

--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -371,7 +371,7 @@ export class JointData {
     damping: number;
     length: number;
 
-    private constructor() {}
+    constructor() {}
 
     /**
      * Creates a new joint descriptor that builds a Fixed joint.

--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -72,7 +72,7 @@ export enum JointAxesMask {
 
 export class ImpulseJoint {
     protected rawSet: RawImpulseJointSet; // The ImpulseJoint won't need to free this.
-    protected bodySet: RigidBodySet; // The ImpulseJoint won’t need to free this.
+    #bodySet: RigidBodySet; // The ImpulseJoint won’t need to free this.
     handle: ImpulseJointHandle;
 
     constructor(
@@ -81,7 +81,7 @@ export class ImpulseJoint {
         handle: ImpulseJointHandle,
     ) {
         this.rawSet = rawSet;
-        this.bodySet = bodySet;
+        this.#bodySet = bodySet;
         this.handle = handle;
     }
 
@@ -114,7 +114,7 @@ export class ImpulseJoint {
 
     /** @internal */
     public finalizeDeserialization(bodySet: RigidBodySet) {
-        this.bodySet = bodySet;
+        this.#bodySet = bodySet;
     }
 
     /**
@@ -129,14 +129,14 @@ export class ImpulseJoint {
      * The first rigid-body this joint it attached to.
      */
     public body1(): RigidBody {
-        return this.bodySet.get(this.rawSet.jointBodyHandle1(this.handle));
+        return this.#bodySet.get(this.rawSet.jointBodyHandle1(this.handle));
     }
 
     /**
      * The second rigid-body this joint is attached to.
      */
     public body2(): RigidBody {
-        return this.bodySet.get(this.rawSet.jointBodyHandle2(this.handle));
+        return this.#bodySet.get(this.rawSet.jointBodyHandle2(this.handle));
     }
 
     /**

--- a/src.ts/dynamics/impulse_joint_set.ts
+++ b/src.ts/dynamics/impulse_joint_set.ts
@@ -25,7 +25,7 @@ import {Collider, ColliderHandle} from "../geometry";
  */
 export class ImpulseJointSet {
     raw: RawImpulseJointSet;
-    private map: Coarena<ImpulseJoint>;
+    #map: Coarena<ImpulseJoint>;
 
     /**
      * Release the WASM memory occupied by this joint set.
@@ -36,26 +36,26 @@ export class ImpulseJointSet {
         }
         this.raw = undefined;
 
-        if (!!this.map) {
-            this.map.clear();
+        if (!!this.#map) {
+            this.#map.clear();
         }
-        this.map = undefined;
+        this.#map = undefined;
     }
 
     constructor(raw?: RawImpulseJointSet) {
         this.raw = raw || new RawImpulseJointSet();
-        this.map = new Coarena<ImpulseJoint>();
+        this.#map = new Coarena<ImpulseJoint>();
         // Initialize the map with the existing elements, if any.
         if (raw) {
             raw.forEachJointHandle((handle: ImpulseJointHandle) => {
-                this.map.set(handle, ImpulseJoint.newTyped(raw, null, handle));
+                this.#map.set(handle, ImpulseJoint.newTyped(raw, null, handle));
             });
         }
     }
 
     /** @internal */
     public finalizeDeserialization(bodies: RigidBodySet) {
-        this.map.forEach((joint) => joint.finalizeDeserialization(bodies));
+        this.#map.forEach((joint) => joint.finalizeDeserialization(bodies));
     }
 
     /**
@@ -83,7 +83,7 @@ export class ImpulseJointSet {
         );
         rawParams.free();
         let joint = ImpulseJoint.newTyped(this.raw, bodies, handle);
-        this.map.set(handle, joint);
+        this.#map.set(handle, joint);
         return joint;
     }
 
@@ -115,14 +115,14 @@ export class ImpulseJointSet {
      * @param handle
      */
     public unmap(handle: ImpulseJointHandle) {
-        this.map.delete(handle);
+        this.#map.delete(handle);
     }
 
     /**
      * The number of joints on this set.
      */
     public len(): number {
-        return this.map.len();
+        return this.#map.len();
     }
 
     /**
@@ -142,7 +142,7 @@ export class ImpulseJointSet {
      * @param handle - The integer handle of the joint to retrieve.
      */
     public get(handle: ImpulseJointHandle): ImpulseJoint | null {
-        return this.map.get(handle);
+        return this.#map.get(handle);
     }
 
     /**
@@ -151,7 +151,7 @@ export class ImpulseJointSet {
      * @param f - The closure to apply.
      */
     public forEach(f: (joint: ImpulseJoint) => void) {
-        this.map.forEach(f);
+        this.#map.forEach(f);
     }
 
     /**
@@ -160,6 +160,6 @@ export class ImpulseJointSet {
      * @returns joint list.
      */
     public getAll(): ImpulseJoint[] {
-        return this.map.getAll();
+        return this.#map.getAll();
     }
 }

--- a/src.ts/dynamics/multibody_joint_set.ts
+++ b/src.ts/dynamics/multibody_joint_set.ts
@@ -24,7 +24,7 @@ import {RigidBodyHandle} from "./rigid_body";
  */
 export class MultibodyJointSet {
     raw: RawMultibodyJointSet;
-    private map: Coarena<MultibodyJoint>;
+    #map: Coarena<MultibodyJoint>;
 
     /**
      * Release the WASM memory occupied by this joint set.
@@ -35,19 +35,19 @@ export class MultibodyJointSet {
         }
         this.raw = undefined;
 
-        if (!!this.map) {
-            this.map.clear();
+        if (!!this.#map) {
+            this.#map.clear();
         }
-        this.map = undefined;
+        this.#map = undefined;
     }
 
     constructor(raw?: RawMultibodyJointSet) {
         this.raw = raw || new RawMultibodyJointSet();
-        this.map = new Coarena<MultibodyJoint>();
+        this.#map = new Coarena<MultibodyJoint>();
         // Initialize the map with the existing elements, if any.
         if (raw) {
             raw.forEachJointHandle((handle: MultibodyJointHandle) => {
-                this.map.set(handle, MultibodyJoint.newTyped(this.raw, handle));
+                this.#map.set(handle, MultibodyJoint.newTyped(this.raw, handle));
             });
         }
     }
@@ -75,7 +75,7 @@ export class MultibodyJointSet {
         );
         rawParams.free();
         let joint = MultibodyJoint.newTyped(this.raw, handle);
-        this.map.set(handle, joint);
+        this.#map.set(handle, joint);
         return joint;
     }
 
@@ -87,7 +87,7 @@ export class MultibodyJointSet {
      */
     public remove(handle: MultibodyJointHandle, wake_up: boolean) {
         this.raw.remove(handle, wake_up);
-        this.map.delete(handle);
+        this.#map.delete(handle);
     }
 
     /**
@@ -95,14 +95,14 @@ export class MultibodyJointSet {
      * @param handle
      */
     public unmap(handle: MultibodyJointHandle) {
-        this.map.delete(handle);
+        this.#map.delete(handle);
     }
 
     /**
      * The number of joints on this set.
      */
     public len(): number {
-        return this.map.len();
+        return this.#map.len();
     }
 
     /**
@@ -122,7 +122,7 @@ export class MultibodyJointSet {
      * @param handle - The integer handle of the joint to retrieve.
      */
     public get(handle: MultibodyJointHandle): MultibodyJoint | null {
-        return this.map.get(handle);
+        return this.#map.get(handle);
     }
 
     /**
@@ -131,7 +131,7 @@ export class MultibodyJointSet {
      * @param f - The closure to apply.
      */
     public forEach(f: (joint: MultibodyJoint) => void) {
-        this.map.forEach(f);
+        this.#map.forEach(f);
     }
 
     /**
@@ -152,6 +152,6 @@ export class MultibodyJointSet {
      * @returns joint list.
      */
     public getAll(): MultibodyJoint[] {
-        return this.map.getAll();
+        return this.#map.getAll();
     }
 }

--- a/src.ts/dynamics/rigid_body.ts
+++ b/src.ts/dynamics/rigid_body.ts
@@ -47,8 +47,8 @@ export enum RigidBodyType {
  * A rigid-body.
  */
 export class RigidBody {
-    private rawSet: RawRigidBodySet; // The RigidBody won't need to free this.
-    private colliderSet: ColliderSet;
+    #rawSet: RawRigidBodySet; // The RigidBody won't need to free this.
+    #colliderSet: ColliderSet;
     readonly handle: RigidBodyHandle;
 
     /**
@@ -61,14 +61,14 @@ export class RigidBody {
         colliderSet: ColliderSet,
         handle: RigidBodyHandle,
     ) {
-        this.rawSet = rawSet;
-        this.colliderSet = colliderSet;
+        this.#rawSet = rawSet;
+        this.#colliderSet = colliderSet;
         this.handle = handle;
     }
 
     /** @internal */
     public finalizeDeserialization(colliderSet: ColliderSet) {
-        this.colliderSet = colliderSet;
+        this.#colliderSet = colliderSet;
     }
 
     /**
@@ -76,7 +76,7 @@ export class RigidBody {
      * not been deleted from the rigid-body set yet.
      */
     public isValid(): boolean {
-        return this.rawSet.contains(this.handle);
+        return this.#rawSet.contains(this.handle);
     }
 
     /**
@@ -86,7 +86,7 @@ export class RigidBody {
      * @param wakeUp - If `true`, this rigid-body will be automatically awaken if it is currently asleep.
      */
     public lockTranslations(locked: boolean, wakeUp: boolean) {
-        return this.rawSet.rbLockTranslations(this.handle, locked, wakeUp);
+        return this.#rawSet.rbLockTranslations(this.handle, locked, wakeUp);
     }
 
     /**
@@ -96,7 +96,7 @@ export class RigidBody {
      * @param wakeUp - If `true`, this rigid-body will be automatically awaken if it is currently asleep.
      */
     public lockRotations(locked: boolean, wakeUp: boolean) {
-        return this.rawSet.rbLockRotations(this.handle, locked, wakeUp);
+        return this.#rawSet.rbLockRotations(this.handle, locked, wakeUp);
     }
 
     // #if DIM2
@@ -112,7 +112,7 @@ export class RigidBody {
         enableY: boolean,
         wakeUp: boolean,
     ) {
-        return this.rawSet.rbSetEnabledTranslations(
+        return this.#rawSet.rbSetEnabledTranslations(
             this.handle,
             enableX,
             enableY,
@@ -152,7 +152,7 @@ export class RigidBody {
         enableZ: boolean,
         wakeUp: boolean,
     ) {
-        return this.rawSet.rbSetEnabledTranslations(
+        return this.#rawSet.rbSetEnabledTranslations(
             this.handle,
             enableX,
             enableY,
@@ -193,7 +193,7 @@ export class RigidBody {
         enableZ: boolean,
         wakeUp: boolean,
     ) {
-        return this.rawSet.rbSetEnabledRotations(
+        return this.#rawSet.rbSetEnabledRotations(
             this.handle,
             enableX,
             enableY,
@@ -226,7 +226,7 @@ export class RigidBody {
      * The dominance group, in [-127, +127] this rigid-body is part of.
      */
     public dominanceGroup(): number {
-        return this.rawSet.rbDominanceGroup(this.handle);
+        return this.#rawSet.rbDominanceGroup(this.handle);
     }
 
     /**
@@ -235,7 +235,7 @@ export class RigidBody {
      * @param group - The dominance group of this rigid-body. Must be a signed integer in the range [-127, +127].
      */
     public setDominanceGroup(group: number) {
-        this.rawSet.rbSetDominanceGroup(this.handle, group);
+        this.#rawSet.rbSetDominanceGroup(this.handle, group);
     }
 
     /**
@@ -244,7 +244,7 @@ export class RigidBody {
      * through contacts or joints.
      */
     public additionalSolverIterations(): number {
-        return this.rawSet.rbAdditionalSolverIterations(this.handle);
+        return this.#rawSet.rbAdditionalSolverIterations(this.handle);
     }
 
     /**
@@ -259,7 +259,7 @@ export class RigidBody {
      * @param iters - The new number of additional solver iterations (default: 0).
      */
     public setAdditionalSolverIterations(iters: number) {
-        this.rawSet.rbSetAdditionalSolverIterations(this.handle, iters);
+        this.#rawSet.rbSetAdditionalSolverIterations(this.handle, iters);
     }
 
     /**
@@ -268,7 +268,7 @@ export class RigidBody {
      * @param enabled - If `true`, CCD will be enabled for this rigid-body.
      */
     public enableCcd(enabled: boolean) {
-        this.rawSet.rbEnableCcd(this.handle, enabled);
+        this.#rawSet.rbEnableCcd(this.handle, enabled);
     }
 
     /**
@@ -278,7 +278,7 @@ export class RigidBody {
      * additional details.
      */
     public setSoftCcdPrediction(distance: number) {
-        this.rawSet.rbSetSoftCcdPrediction(this.handle, distance);
+        this.#rawSet.rbSetSoftCcdPrediction(this.handle, distance);
     }
 
     /**
@@ -288,14 +288,14 @@ export class RigidBody {
      * additional details.
      */
     public softCcdPrediction(): number {
-        return this.rawSet.rbSoftCcdPrediction(this.handle);
+        return this.#rawSet.rbSoftCcdPrediction(this.handle);
     }
 
     /**
      * The world-space translation of this rigid-body.
      */
     public translation(): Vector {
-        let res = this.rawSet.rbTranslation(this.handle);
+        let res = this.#rawSet.rbTranslation(this.handle);
         return VectorOps.fromRaw(res);
     }
 
@@ -303,7 +303,7 @@ export class RigidBody {
      * The world-space orientation of this rigid-body.
      */
     public rotation(): Rotation {
-        let res = this.rawSet.rbRotation(this.handle);
+        let res = this.#rawSet.rbRotation(this.handle);
         return RotationOps.fromRaw(res);
     }
 
@@ -315,7 +315,7 @@ export class RigidBody {
      * For non-kinematic bodies, this value is currently unspecified.
      */
     public nextTranslation(): Vector {
-        let res = this.rawSet.rbNextTranslation(this.handle);
+        let res = this.#rawSet.rbNextTranslation(this.handle);
         return VectorOps.fromRaw(res);
     }
 
@@ -327,7 +327,7 @@ export class RigidBody {
      * For non-kinematic bodies, this value is currently unspecified.
      */
     public nextRotation(): Rotation {
-        let res = this.rawSet.rbNextRotation(this.handle);
+        let res = this.#rawSet.rbNextRotation(this.handle);
         return RotationOps.fromRaw(res);
     }
 
@@ -340,10 +340,10 @@ export class RigidBody {
      */
     public setTranslation(tra: Vector, wakeUp: boolean) {
         // #if DIM2
-        this.rawSet.rbSetTranslation(this.handle, tra.x, tra.y, wakeUp);
+        this.#rawSet.rbSetTranslation(this.handle, tra.x, tra.y, wakeUp);
         // #endif
         // #if DIM3
-        this.rawSet.rbSetTranslation(this.handle, tra.x, tra.y, tra.z, wakeUp);
+        this.#rawSet.rbSetTranslation(this.handle, tra.x, tra.y, tra.z, wakeUp);
         // #endif
     }
 
@@ -355,7 +355,7 @@ export class RigidBody {
      */
     public setLinvel(vel: Vector, wakeUp: boolean) {
         let rawVel = VectorOps.intoRaw(vel);
-        this.rawSet.rbSetLinvel(this.handle, rawVel, wakeUp);
+        this.#rawSet.rbSetLinvel(this.handle, rawVel, wakeUp);
         rawVel.free();
     }
 
@@ -364,7 +364,7 @@ export class RigidBody {
      * this rigid-body.
      */
     public gravityScale(): number {
-        return this.rawSet.rbGravityScale(this.handle);
+        return this.#rawSet.rbGravityScale(this.handle);
     }
 
     /**
@@ -376,7 +376,7 @@ export class RigidBody {
      * @param wakeUp - Forces the rigid-body to wake-up if it was asleep.
      */
     public setGravityScale(factor: number, wakeUp: boolean) {
-        this.rawSet.rbSetGravityScale(this.handle, factor, wakeUp);
+        this.#rawSet.rbSetGravityScale(this.handle, factor, wakeUp);
     }
 
     // #if DIM3
@@ -390,7 +390,7 @@ export class RigidBody {
      * wasn't moving before modifying its position.
      */
     public setRotation(rot: Rotation, wakeUp: boolean) {
-        this.rawSet.rbSetRotation(
+        this.#rawSet.rbSetRotation(
             this.handle,
             rot.x,
             rot.y,
@@ -408,7 +408,7 @@ export class RigidBody {
      */
     public setAngvel(vel: Vector, wakeUp: boolean) {
         let rawVel = VectorOps.intoRaw(vel);
-        this.rawSet.rbSetAngvel(this.handle, rawVel, wakeUp);
+        this.#rawSet.rbSetAngvel(this.handle, rawVel, wakeUp);
         rawVel.free();
     }
 
@@ -423,7 +423,7 @@ export class RigidBody {
      * wasn't moving before modifying its position.
      */
     public setRotation(angle: number, wakeUp: boolean) {
-        this.rawSet.rbSetRotation(this.handle, angle, wakeUp);
+        this.#rawSet.rbSetRotation(this.handle, angle, wakeUp);
     }
 
     /**
@@ -433,7 +433,7 @@ export class RigidBody {
      * @param wakeUp - Forces the rigid-body to wake-up if it was asleep.
      */
     public setAngvel(vel: number, wakeUp: boolean) {
-        this.rawSet.rbSetAngvel(this.handle, vel, wakeUp);
+        this.#rawSet.rbSetAngvel(this.handle, vel, wakeUp);
     }
 
     // #endif
@@ -451,10 +451,10 @@ export class RigidBody {
      */
     public setNextKinematicTranslation(t: Vector) {
         // #if DIM2
-        this.rawSet.rbSetNextKinematicTranslation(this.handle, t.x, t.y);
+        this.#rawSet.rbSetNextKinematicTranslation(this.handle, t.x, t.y);
         // #endif
         // #if DIM3
-        this.rawSet.rbSetNextKinematicTranslation(this.handle, t.x, t.y, t.z);
+        this.#rawSet.rbSetNextKinematicTranslation(this.handle, t.x, t.y, t.z);
         // #endif
     }
 
@@ -471,7 +471,7 @@ export class RigidBody {
      * @param rot - The kinematic rotation to set.
      */
     public setNextKinematicRotation(rot: Rotation) {
-        this.rawSet.rbSetNextKinematicRotation(
+        this.#rawSet.rbSetNextKinematicRotation(
             this.handle,
             rot.x,
             rot.y,
@@ -495,7 +495,7 @@ export class RigidBody {
      * @param angle - The kinematic rotation angle, in radians.
      */
     public setNextKinematicRotation(angle: number) {
-        this.rawSet.rbSetNextKinematicRotation(this.handle, angle);
+        this.#rawSet.rbSetNextKinematicRotation(this.handle, angle);
     }
 
     // #endif
@@ -504,7 +504,7 @@ export class RigidBody {
      * The linear velocity of this rigid-body.
      */
     public linvel(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbLinvel(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbLinvel(this.handle));
     }
 
     /**
@@ -513,7 +513,7 @@ export class RigidBody {
     public velocityAtPoint(point: Vector): Vector {
         const rawPoint = VectorOps.intoRaw(point);
         let result = VectorOps.fromRaw(
-            this.rawSet.rbVelocityAtPoint(this.handle, rawPoint),
+            this.#rawSet.rbVelocityAtPoint(this.handle, rawPoint),
         );
         rawPoint.free();
         return result;
@@ -524,7 +524,7 @@ export class RigidBody {
      * The angular velocity of this rigid-body.
      */
     public angvel(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbAngvel(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbAngvel(this.handle));
     }
 
     // #endif
@@ -534,7 +534,7 @@ export class RigidBody {
      * The angular velocity of this rigid-body.
      */
     public angvel(): number {
-        return this.rawSet.rbAngvel(this.handle);
+        return this.#rawSet.rbAngvel(this.handle);
     }
 
     // #endif
@@ -543,14 +543,14 @@ export class RigidBody {
      * The mass of this rigid-body.
      */
     public mass(): number {
-        return this.rawSet.rbMass(this.handle);
+        return this.#rawSet.rbMass(this.handle);
     }
 
     /**
      * The inverse mass taking into account translation locking.
      */
     public effectiveInvMass(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbEffectiveInvMass(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbEffectiveInvMass(this.handle));
     }
 
     /**
@@ -559,21 +559,21 @@ export class RigidBody {
      * If this is zero, the rigid-body is assumed to have infinite mass.
      */
     public invMass(): number {
-        return this.rawSet.rbInvMass(this.handle);
+        return this.#rawSet.rbInvMass(this.handle);
     }
 
     /**
      * The center of mass of a rigid-body expressed in its local-space.
      */
     public localCom(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbLocalCom(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbLocalCom(this.handle));
     }
 
     /**
      * The world-space center of mass of the rigid-body.
      */
     public worldCom(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbWorldCom(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbWorldCom(this.handle));
     }
 
     // #if DIM2
@@ -583,7 +583,7 @@ export class RigidBody {
      * Components set to zero are assumed to be infinite along the corresponding principal axis.
      */
     public invPrincipalInertia(): number {
-        return this.rawSet.rbInvPrincipalInertia(this.handle);
+        return this.#rawSet.rbInvPrincipalInertia(this.handle);
     }
 
     // #endif
@@ -596,7 +596,7 @@ export class RigidBody {
      */
     public invPrincipalInertia(): Vector {
         return VectorOps.fromRaw(
-            this.rawSet.rbInvPrincipalInertia(this.handle),
+            this.#rawSet.rbInvPrincipalInertia(this.handle),
         );
     }
 
@@ -607,7 +607,7 @@ export class RigidBody {
      * The angular inertia along the principal inertia axes of the rigid-body.
      */
     public principalInertia(): number {
-        return this.rawSet.rbPrincipalInertia(this.handle);
+        return this.#rawSet.rbPrincipalInertia(this.handle);
     }
 
     // #endif
@@ -617,7 +617,7 @@ export class RigidBody {
      * The angular inertia along the principal inertia axes of the rigid-body.
      */
     public principalInertia(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbPrincipalInertia(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbPrincipalInertia(this.handle));
     }
 
     // #endif
@@ -628,7 +628,7 @@ export class RigidBody {
      */
     public principalInertiaLocalFrame(): Rotation {
         return RotationOps.fromRaw(
-            this.rawSet.rbPrincipalInertiaLocalFrame(this.handle),
+            this.#rawSet.rbPrincipalInertiaLocalFrame(this.handle),
         );
     }
 
@@ -640,7 +640,7 @@ export class RigidBody {
      * taking into account rotation locking.
      */
     public effectiveWorldInvInertia(): number {
-        return this.rawSet.rbEffectiveWorldInvInertia(this.handle);
+        return this.#rawSet.rbEffectiveWorldInvInertia(this.handle);
     }
 
     // #endif
@@ -652,7 +652,7 @@ export class RigidBody {
      */
     public effectiveWorldInvInertia(): SdpMatrix3 {
         return SdpMatrix3Ops.fromRaw(
-            this.rawSet.rbEffectiveWorldInvInertia(this.handle),
+            this.#rawSet.rbEffectiveWorldInvInertia(this.handle),
         );
     }
 
@@ -664,7 +664,7 @@ export class RigidBody {
      * this rigid-body.
      */
     public effectiveAngularInertia(): number {
-        return this.rawSet.rbEffectiveAngularInertia(this.handle);
+        return this.#rawSet.rbEffectiveAngularInertia(this.handle);
     }
 
     // #endif
@@ -676,7 +676,7 @@ export class RigidBody {
      */
     public effectiveAngularInertia(): SdpMatrix3 {
         return SdpMatrix3Ops.fromRaw(
-            this.rawSet.rbEffectiveAngularInertia(this.handle),
+            this.#rawSet.rbEffectiveAngularInertia(this.handle),
         );
     }
 
@@ -690,7 +690,7 @@ export class RigidBody {
      * external forces like contacts.
      */
     public sleep() {
-        this.rawSet.rbSleep(this.handle);
+        this.#rawSet.rbSleep(this.handle);
     }
 
     /**
@@ -703,21 +703,21 @@ export class RigidBody {
      * the position of a dynamic body so that it is properly simulated afterwards.
      */
     public wakeUp() {
-        this.rawSet.rbWakeUp(this.handle);
+        this.#rawSet.rbWakeUp(this.handle);
     }
 
     /**
      * Is CCD enabled for this rigid-body?
      */
     public isCcdEnabled(): boolean {
-        return this.rawSet.rbIsCcdEnabled(this.handle);
+        return this.#rawSet.rbIsCcdEnabled(this.handle);
     }
 
     /**
      * The number of colliders attached to this rigid-body.
      */
     public numColliders(): number {
-        return this.rawSet.rbNumColliders(this.handle);
+        return this.#rawSet.rbNumColliders(this.handle);
     }
 
     /**
@@ -727,7 +727,7 @@ export class RigidBody {
      *         This index is **not** the same as the unique identifier of the collider.
      */
     public collider(i: number): Collider {
-        return this.colliderSet.get(this.rawSet.rbCollider(this.handle, i));
+        return this.#colliderSet.get(this.#rawSet.rbCollider(this.handle, i));
     }
 
     /**
@@ -736,28 +736,28 @@ export class RigidBody {
      * @param enabled - Set to `false` to disable this rigid-body and all its attached colliders.
      */
     public setEnabled(enabled: boolean) {
-        this.rawSet.rbSetEnabled(this.handle, enabled);
+        this.#rawSet.rbSetEnabled(this.handle, enabled);
     }
 
     /**
      * Is this rigid-body enabled?
      */
     public isEnabled(): boolean {
-        return this.rawSet.rbIsEnabled(this.handle);
+        return this.#rawSet.rbIsEnabled(this.handle);
     }
 
     /**
      * The status of this rigid-body: static, dynamic, or kinematic.
      */
     public bodyType(): RigidBodyType {
-        return this.rawSet.rbBodyType(this.handle) as number as RigidBodyType;
+        return this.#rawSet.rbBodyType(this.handle) as number as RigidBodyType;
     }
 
     /**
      * Set a new status for this rigid-body: static, dynamic, or kinematic.
      */
     public setBodyType(type: RigidBodyType, wakeUp: boolean) {
-        return this.rawSet.rbSetBodyType(
+        return this.#rawSet.rbSetBodyType(
             this.handle,
             type as number as RawRigidBodyType,
             wakeUp,
@@ -768,49 +768,49 @@ export class RigidBody {
      * Is this rigid-body sleeping?
      */
     public isSleeping(): boolean {
-        return this.rawSet.rbIsSleeping(this.handle);
+        return this.#rawSet.rbIsSleeping(this.handle);
     }
 
     /**
      * Is the velocity of this rigid-body not zero?
      */
     public isMoving(): boolean {
-        return this.rawSet.rbIsMoving(this.handle);
+        return this.#rawSet.rbIsMoving(this.handle);
     }
 
     /**
      * Is this rigid-body static?
      */
     public isFixed(): boolean {
-        return this.rawSet.rbIsFixed(this.handle);
+        return this.#rawSet.rbIsFixed(this.handle);
     }
 
     /**
      * Is this rigid-body kinematic?
      */
     public isKinematic(): boolean {
-        return this.rawSet.rbIsKinematic(this.handle);
+        return this.#rawSet.rbIsKinematic(this.handle);
     }
 
     /**
      * Is this rigid-body dynamic?
      */
     public isDynamic(): boolean {
-        return this.rawSet.rbIsDynamic(this.handle);
+        return this.#rawSet.rbIsDynamic(this.handle);
     }
 
     /**
      * The linear damping coefficient of this rigid-body.
      */
     public linearDamping(): number {
-        return this.rawSet.rbLinearDamping(this.handle);
+        return this.#rawSet.rbLinearDamping(this.handle);
     }
 
     /**
      * The angular damping coefficient of this rigid-body.
      */
     public angularDamping(): number {
-        return this.rawSet.rbAngularDamping(this.handle);
+        return this.#rawSet.rbAngularDamping(this.handle);
     }
 
     /**
@@ -819,16 +819,16 @@ export class RigidBody {
      * @param factor - The damping factor to set.
      */
     public setLinearDamping(factor: number) {
-        this.rawSet.rbSetLinearDamping(this.handle, factor);
+        this.#rawSet.rbSetLinearDamping(this.handle, factor);
     }
 
     /**
      * Recompute the mass-properties of this rigid-bodies based on its currently attached colliders.
      */
     public recomputeMassPropertiesFromColliders() {
-        this.rawSet.rbRecomputeMassPropertiesFromColliders(
+        this.#rawSet.rbRecomputeMassPropertiesFromColliders(
             this.handle,
-            this.colliderSet.raw,
+            this.#colliderSet.raw,
         );
     }
 
@@ -852,7 +852,7 @@ export class RigidBody {
      * @param wakeUp - If `true` then the rigid-body will be woken up if it was put to sleep because it did not move for a while.
      */
     public setAdditionalMass(mass: number, wakeUp: boolean) {
-        this.rawSet.rbSetAdditionalMass(this.handle, mass, wakeUp);
+        this.#rawSet.rbSetAdditionalMass(this.handle, mass, wakeUp);
     }
 
     // #if DIM3
@@ -883,7 +883,7 @@ export class RigidBody {
         let rawPrincipalInertia = VectorOps.intoRaw(principalAngularInertia);
         let rawInertiaFrame = RotationOps.intoRaw(angularInertiaLocalFrame);
 
-        this.rawSet.rbSetAdditionalMassProperties(
+        this.#rawSet.rbSetAdditionalMassProperties(
             this.handle,
             mass,
             rawCom,
@@ -923,7 +923,7 @@ export class RigidBody {
         wakeUp: boolean,
     ) {
         let rawCom = VectorOps.intoRaw(centerOfMass);
-        this.rawSet.rbSetAdditionalMassProperties(
+        this.#rawSet.rbSetAdditionalMassProperties(
             this.handle,
             mass,
             rawCom,
@@ -941,7 +941,7 @@ export class RigidBody {
      * @param factor - The damping factor to set.
      */
     public setAngularDamping(factor: number) {
-        this.rawSet.rbSetAngularDamping(this.handle, factor);
+        this.#rawSet.rbSetAngularDamping(this.handle, factor);
     }
 
     /**
@@ -950,7 +950,7 @@ export class RigidBody {
      * @param wakeUp - should the rigid-body be automatically woken-up?
      */
     public resetForces(wakeUp: boolean) {
-        this.rawSet.rbResetForces(this.handle, wakeUp);
+        this.#rawSet.rbResetForces(this.handle, wakeUp);
     }
 
     /**
@@ -959,7 +959,7 @@ export class RigidBody {
      * @param wakeUp - should the rigid-body be automatically woken-up?
      */
     public resetTorques(wakeUp: boolean) {
-        this.rawSet.rbResetTorques(this.handle, wakeUp);
+        this.#rawSet.rbResetTorques(this.handle, wakeUp);
     }
 
     /**
@@ -970,7 +970,7 @@ export class RigidBody {
      */
     public addForce(force: Vector, wakeUp: boolean) {
         const rawForce = VectorOps.intoRaw(force);
-        this.rawSet.rbAddForce(this.handle, rawForce, wakeUp);
+        this.#rawSet.rbAddForce(this.handle, rawForce, wakeUp);
         rawForce.free();
     }
 
@@ -982,7 +982,7 @@ export class RigidBody {
      */
     public applyImpulse(impulse: Vector, wakeUp: boolean) {
         const rawImpulse = VectorOps.intoRaw(impulse);
-        this.rawSet.rbApplyImpulse(this.handle, rawImpulse, wakeUp);
+        this.#rawSet.rbApplyImpulse(this.handle, rawImpulse, wakeUp);
         rawImpulse.free();
     }
 
@@ -994,7 +994,7 @@ export class RigidBody {
      * @param wakeUp - should the rigid-body be automatically woken-up?
      */
     public addTorque(torque: number, wakeUp: boolean) {
-        this.rawSet.rbAddTorque(this.handle, torque, wakeUp);
+        this.#rawSet.rbAddTorque(this.handle, torque, wakeUp);
     }
 
     // #endif
@@ -1008,7 +1008,7 @@ export class RigidBody {
      */
     public addTorque(torque: Vector, wakeUp: boolean) {
         const rawTorque = VectorOps.intoRaw(torque);
-        this.rawSet.rbAddTorque(this.handle, rawTorque, wakeUp);
+        this.#rawSet.rbAddTorque(this.handle, rawTorque, wakeUp);
         rawTorque.free();
     }
 
@@ -1022,7 +1022,7 @@ export class RigidBody {
      * @param wakeUp - should the rigid-body be automatically woken-up?
      */
     public applyTorqueImpulse(torqueImpulse: number, wakeUp: boolean) {
-        this.rawSet.rbApplyTorqueImpulse(this.handle, torqueImpulse, wakeUp);
+        this.#rawSet.rbApplyTorqueImpulse(this.handle, torqueImpulse, wakeUp);
     }
 
     // #endif
@@ -1036,7 +1036,7 @@ export class RigidBody {
      */
     public applyTorqueImpulse(torqueImpulse: Vector, wakeUp: boolean) {
         const rawTorqueImpulse = VectorOps.intoRaw(torqueImpulse);
-        this.rawSet.rbApplyTorqueImpulse(this.handle, rawTorqueImpulse, wakeUp);
+        this.#rawSet.rbApplyTorqueImpulse(this.handle, rawTorqueImpulse, wakeUp);
         rawTorqueImpulse.free();
     }
 
@@ -1052,7 +1052,7 @@ export class RigidBody {
     public addForceAtPoint(force: Vector, point: Vector, wakeUp: boolean) {
         const rawForce = VectorOps.intoRaw(force);
         const rawPoint = VectorOps.intoRaw(point);
-        this.rawSet.rbAddForceAtPoint(this.handle, rawForce, rawPoint, wakeUp);
+        this.#rawSet.rbAddForceAtPoint(this.handle, rawForce, rawPoint, wakeUp);
         rawForce.free();
         rawPoint.free();
     }
@@ -1071,7 +1071,7 @@ export class RigidBody {
     ) {
         const rawImpulse = VectorOps.intoRaw(impulse);
         const rawPoint = VectorOps.intoRaw(point);
-        this.rawSet.rbApplyImpulseAtPoint(
+        this.#rawSet.rbApplyImpulseAtPoint(
             this.handle,
             rawImpulse,
             rawPoint,
@@ -1086,7 +1086,7 @@ export class RigidBody {
      * Returns zero if the rigid-body is not dynamic.
      */
     public userForce(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbUserForce(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbUserForce(this.handle));
     }
 
     // #if DIM2
@@ -1095,7 +1095,7 @@ export class RigidBody {
      * Returns zero if the rigid-body is not dynamic.
      */
     public userTorque(): number {
-        return this.rawSet.rbUserTorque(this.handle);
+        return this.#rawSet.rbUserTorque(this.handle);
     }
     // #endif
 
@@ -1105,7 +1105,7 @@ export class RigidBody {
      * Returns zero if the rigid-body is not dynamic.
      */
     public userTorque(): Vector {
-        return VectorOps.fromRaw(this.rawSet.rbUserTorque(this.handle));
+        return VectorOps.fromRaw(this.#rawSet.rbUserTorque(this.handle));
     }
     // #endif
 }

--- a/src.ts/dynamics/rigid_body_set.ts
+++ b/src.ts/dynamics/rigid_body_set.ts
@@ -20,7 +20,7 @@ import {IslandManager} from "./island_manager";
  */
 export class RigidBodySet {
     raw: RawRigidBodySet;
-    private map: Coarena<RigidBody>;
+    #map: Coarena<RigidBody>;
 
     /**
      * Release the WASM memory occupied by this rigid-body set.
@@ -31,19 +31,19 @@ export class RigidBodySet {
         }
         this.raw = undefined;
 
-        if (!!this.map) {
-            this.map.clear();
+        if (!!this.#map) {
+            this.#map.clear();
         }
-        this.map = undefined;
+        this.#map = undefined;
     }
 
     constructor(raw?: RawRigidBodySet) {
         this.raw = raw || new RawRigidBodySet();
-        this.map = new Coarena<RigidBody>();
+        this.#map = new Coarena<RigidBody>();
         // deserialize
         if (raw) {
             raw.forEachRigidBodyHandle((handle: RigidBodyHandle) => {
-                this.map.set(handle, new RigidBody(raw, null, handle));
+                this.#map.set(handle, new RigidBody(raw, null, handle));
             });
         }
     }
@@ -52,7 +52,7 @@ export class RigidBodySet {
      * Internal method, do not call this explicitly.
      */
     public finalizeDeserialization(colliderSet: ColliderSet) {
-        this.map.forEach((rb) => rb.finalizeDeserialization(colliderSet));
+        this.#map.forEach((rb) => rb.finalizeDeserialization(colliderSet));
     }
 
     /**
@@ -131,7 +131,7 @@ export class RigidBodySet {
         const body = new RigidBody(this.raw, colliderSet, handle);
         body.userData = desc.userData;
 
-        this.map.set(handle, body);
+        this.#map.set(handle, body);
 
         return body;
     }
@@ -174,14 +174,14 @@ export class RigidBodySet {
             impulseJoints.raw,
             multibodyJoints.raw,
         );
-        this.map.delete(handle);
+        this.#map.delete(handle);
     }
 
     /**
      * The number of rigid-bodies on this set.
      */
     public len(): number {
-        return this.map.len();
+        return this.#map.len();
     }
 
     /**
@@ -199,7 +199,7 @@ export class RigidBodySet {
      * @param handle - The handle of the rigid-body to retrieve.
      */
     public get(handle: RigidBodyHandle): RigidBody | null {
-        return this.map.get(handle);
+        return this.#map.get(handle);
     }
 
     /**
@@ -208,7 +208,7 @@ export class RigidBodySet {
      * @param f - The closure to apply.
      */
     public forEach(f: (body: RigidBody) => void) {
-        this.map.forEach(f);
+        this.#map.forEach(f);
     }
 
     /**
@@ -233,6 +233,6 @@ export class RigidBodySet {
      * @returns rigid-bodies list.
      */
     public getAll(): RigidBody[] {
-        return this.map.getAll();
+        return this.#map.getAll();
     }
 }

--- a/src.ts/geometry/collider.ts
+++ b/src.ts/geometry/collider.ts
@@ -108,10 +108,10 @@ export type ColliderHandle = number;
  * by contacts and proximity queries.
  */
 export class Collider {
-    private colliderSet: ColliderSet; // The Collider won't need to free this.
+    #colliderSet: ColliderSet; // The Collider won't need to free this.
     readonly handle: ColliderHandle;
-    private _shape: Shape; // TODO: deprecate/remove this since it isn’t a reliable way of getting the latest shape properties.
-    private _parent: RigidBody | null;
+    #_shape: Shape; // TODO: deprecate/remove this since it isn’t a reliable way of getting the latest shape properties.
+    #_parent: RigidBody | null;
 
     constructor(
         colliderSet: ColliderSet,
@@ -119,32 +119,32 @@ export class Collider {
         parent: RigidBody | null,
         shape?: Shape,
     ) {
-        this.colliderSet = colliderSet;
+        this.#colliderSet = colliderSet;
         this.handle = handle;
-        this._parent = parent;
-        this._shape = shape;
+        this.#_parent = parent;
+        this.#_shape = shape;
     }
 
     /** @internal */
     public finalizeDeserialization(bodies: RigidBodySet) {
         if (this.handle != null) {
-            this._parent = bodies.get(
-                this.colliderSet.raw.coParent(this.handle),
+            this.#_parent = bodies.get(
+                this.#colliderSet.raw.coParent(this.handle),
             );
         }
     }
 
-    private ensureShapeIsCached() {
-        if (!this._shape)
-            this._shape = Shape.fromRaw(this.colliderSet.raw, this.handle);
+    #ensureShapeIsCached() {
+        if (!this.#_shape)
+            this.#_shape = Shape.fromRaw(this.#colliderSet.raw, this.handle);
     }
 
     /**
      * The shape of this collider.
      */
     public get shape(): Shape {
-        this.ensureShapeIsCached();
-        return this._shape;
+        this.#ensureShapeIsCached();
+        return this.#_shape;
     }
 
     /**
@@ -156,7 +156,7 @@ export class Collider {
      * accessed) from the WASM source of truth.
      */
     public clearShapeCache() {
-        this._shape = null;
+        this.#_shape = null;
     }
 
     /**
@@ -164,7 +164,7 @@ export class Collider {
      * not been deleted from the collider set yet).
      */
     public isValid(): boolean {
-        return this.colliderSet.raw.contains(this.handle);
+        return this.#colliderSet.raw.contains(this.handle);
     }
 
     /**
@@ -172,7 +172,7 @@ export class Collider {
      */
     public translation(): Vector {
         return VectorOps.fromRaw(
-            this.colliderSet.raw.coTranslation(this.handle),
+            this.#colliderSet.raw.coTranslation(this.handle),
         );
     }
 
@@ -183,7 +183,7 @@ export class Collider {
      */
     public translationWrtParent(): Vector | null {
         return VectorOps.fromRaw(
-            this.colliderSet.raw.coTranslationWrtParent(this.handle),
+            this.#colliderSet.raw.coTranslationWrtParent(this.handle),
         );
     }
 
@@ -192,7 +192,7 @@ export class Collider {
      */
     public rotation(): Rotation {
         return RotationOps.fromRaw(
-            this.colliderSet.raw.coRotation(this.handle),
+            this.#colliderSet.raw.coRotation(this.handle),
         );
     }
 
@@ -203,7 +203,7 @@ export class Collider {
      */
     public rotationWrtParent(): Rotation | null {
         return RotationOps.fromRaw(
-            this.colliderSet.raw.coRotationWrtParent(this.handle),
+            this.#colliderSet.raw.coRotationWrtParent(this.handle),
         );
     }
 
@@ -211,7 +211,7 @@ export class Collider {
      * Is this collider a sensor?
      */
     public isSensor(): boolean {
-        return this.colliderSet.raw.coIsSensor(this.handle);
+        return this.#colliderSet.raw.coIsSensor(this.handle);
     }
 
     /**
@@ -219,7 +219,7 @@ export class Collider {
      * @param isSensor - If `true`, the collider will be a sensor.
      */
     public setSensor(isSensor: boolean) {
-        this.colliderSet.raw.coSetSensor(this.handle, isSensor);
+        this.#colliderSet.raw.coSetSensor(this.handle, isSensor);
     }
 
     /**
@@ -228,9 +228,9 @@ export class Collider {
      */
     public setShape(shape: Shape) {
         let rawShape = shape.intoRaw();
-        this.colliderSet.raw.coSetShape(this.handle, rawShape);
+        this.#colliderSet.raw.coSetShape(this.handle, rawShape);
         rawShape.free();
-        this._shape = shape;
+        this.#_shape = shape;
     }
 
     /**
@@ -239,14 +239,14 @@ export class Collider {
      * @param enabled - Set to `false` to disable this collider (its parent rigid-body won’t be disabled automatically by this).
      */
     public setEnabled(enabled: boolean) {
-        this.colliderSet.raw.coSetEnabled(this.handle, enabled);
+        this.#colliderSet.raw.coSetEnabled(this.handle, enabled);
     }
 
     /**
      * Is this collider enabled?
      */
     public isEnabled(): boolean {
-        return this.colliderSet.raw.coIsEnabled(this.handle);
+        return this.#colliderSet.raw.coIsEnabled(this.handle);
     }
 
     /**
@@ -257,7 +257,7 @@ export class Collider {
      *                   constraints solver).
      */
     public setRestitution(restitution: number) {
-        this.colliderSet.raw.coSetRestitution(this.handle, restitution);
+        this.#colliderSet.raw.coSetRestitution(this.handle, restitution);
     }
 
     /**
@@ -268,7 +268,7 @@ export class Collider {
      *                   being built.
      */
     public setFriction(friction: number) {
-        this.colliderSet.raw.coSetFriction(this.handle, friction);
+        this.#colliderSet.raw.coSetFriction(this.handle, friction);
     }
 
     /**
@@ -276,7 +276,7 @@ export class Collider {
      * colliders involved in a contact.
      */
     public frictionCombineRule(): CoefficientCombineRule {
-        return this.colliderSet.raw.coFrictionCombineRule(this.handle);
+        return this.#colliderSet.raw.coFrictionCombineRule(this.handle);
     }
 
     /**
@@ -286,7 +286,7 @@ export class Collider {
      * @param rule − The combine rule to apply.
      */
     public setFrictionCombineRule(rule: CoefficientCombineRule) {
-        this.colliderSet.raw.coSetFrictionCombineRule(this.handle, rule);
+        this.#colliderSet.raw.coSetFrictionCombineRule(this.handle, rule);
     }
 
     /**
@@ -294,7 +294,7 @@ export class Collider {
      * colliders involved in a contact.
      */
     public restitutionCombineRule(): CoefficientCombineRule {
-        return this.colliderSet.raw.coRestitutionCombineRule(this.handle);
+        return this.#colliderSet.raw.coRestitutionCombineRule(this.handle);
     }
 
     /**
@@ -304,7 +304,7 @@ export class Collider {
      * @param rule − The combine rule to apply.
      */
     public setRestitutionCombineRule(rule: CoefficientCombineRule) {
-        this.colliderSet.raw.coSetRestitutionCombineRule(this.handle, rule);
+        this.#colliderSet.raw.coSetRestitutionCombineRule(this.handle, rule);
     }
 
     /**
@@ -316,7 +316,7 @@ export class Collider {
      * @param groups - The collision groups used for the collider being built.
      */
     public setCollisionGroups(groups: InteractionGroups) {
-        this.colliderSet.raw.coSetCollisionGroups(this.handle, groups);
+        this.#colliderSet.raw.coSetCollisionGroups(this.handle, groups);
     }
 
     /**
@@ -329,7 +329,7 @@ export class Collider {
      * @param groups - The solver groups used for the collider being built.
      */
     public setSolverGroups(groups: InteractionGroups) {
-        this.colliderSet.raw.coSetSolverGroups(this.handle, groups);
+        this.#colliderSet.raw.coSetSolverGroups(this.handle, groups);
     }
 
     /**
@@ -338,7 +338,7 @@ export class Collider {
      * See the documentation of `ColliderDesc.setContactSkin` for additional details.
      */
     public contactSkin(): number {
-        return this.colliderSet.raw.coContactSkin(this.handle);
+        return this.#colliderSet.raw.coContactSkin(this.handle);
     }
 
     /**
@@ -349,14 +349,14 @@ export class Collider {
      * @param thickness - The contact skin thickness.
      */
     public setContactSkin(thickness: number) {
-        return this.colliderSet.raw.coSetContactSkin(this.handle, thickness);
+        return this.#colliderSet.raw.coSetContactSkin(this.handle, thickness);
     }
 
     /**
      * Get the physics hooks active for this collider.
      */
     public activeHooks(): ActiveHooks {
-        return this.colliderSet.raw.coActiveHooks(this.handle);
+        return this.#colliderSet.raw.coActiveHooks(this.handle);
     }
 
     /**
@@ -367,14 +367,14 @@ export class Collider {
      * @param activeHooks - The hooks active for contact/intersection pairs involving this collider.
      */
     public setActiveHooks(activeHooks: ActiveHooks) {
-        this.colliderSet.raw.coSetActiveHooks(this.handle, activeHooks);
+        this.#colliderSet.raw.coSetActiveHooks(this.handle, activeHooks);
     }
 
     /**
      * The events active for this collider.
      */
     public activeEvents(): ActiveEvents {
-        return this.colliderSet.raw.coActiveEvents(this.handle);
+        return this.#colliderSet.raw.coActiveEvents(this.handle);
     }
 
     /**
@@ -385,14 +385,14 @@ export class Collider {
      * @param activeEvents - The events active for contact/intersection pairs involving this collider.
      */
     public setActiveEvents(activeEvents: ActiveEvents) {
-        this.colliderSet.raw.coSetActiveEvents(this.handle, activeEvents);
+        this.#colliderSet.raw.coSetActiveEvents(this.handle, activeEvents);
     }
 
     /**
      * Gets the collision types active for this collider.
      */
     public activeCollisionTypes(): ActiveCollisionTypes {
-        return this.colliderSet.raw.coActiveCollisionTypes(this.handle);
+        return this.#colliderSet.raw.coActiveCollisionTypes(this.handle);
     }
 
     /**
@@ -401,7 +401,7 @@ export class Collider {
      * @param threshold - The new force threshold.
      */
     public setContactForceEventThreshold(threshold: number) {
-        return this.colliderSet.raw.coSetContactForceEventThreshold(
+        return this.#colliderSet.raw.coSetContactForceEventThreshold(
             this.handle,
             threshold,
         );
@@ -411,7 +411,7 @@ export class Collider {
      * The total force magnitude beyond which a contact force event can be emitted.
      */
     public contactForceEventThreshold(): number {
-        return this.colliderSet.raw.coContactForceEventThreshold(this.handle);
+        return this.#colliderSet.raw.coContactForceEventThreshold(this.handle);
     }
 
     /**
@@ -420,7 +420,7 @@ export class Collider {
      * @param activeCollisionTypes - The hooks active for contact/intersection pairs involving this collider.
      */
     public setActiveCollisionTypes(activeCollisionTypes: ActiveCollisionTypes) {
-        this.colliderSet.raw.coSetActiveCollisionTypes(
+        this.#colliderSet.raw.coSetActiveCollisionTypes(
             this.handle,
             activeCollisionTypes,
         );
@@ -437,7 +437,7 @@ export class Collider {
      * shape.
      */
     public setDensity(density: number) {
-        this.colliderSet.raw.coSetDensity(this.handle, density);
+        this.#colliderSet.raw.coSetDensity(this.handle, density);
     }
 
     /**
@@ -451,7 +451,7 @@ export class Collider {
      * and this mass value.
      */
     public setMass(mass: number) {
-        this.colliderSet.raw.coSetMass(this.handle, mass);
+        this.#colliderSet.raw.coSetMass(this.handle, mass);
     }
 
     // #if DIM3
@@ -472,7 +472,7 @@ export class Collider {
         let rawPrincipalInertia = VectorOps.intoRaw(principalAngularInertia);
         let rawInertiaFrame = RotationOps.intoRaw(angularInertiaLocalFrame);
 
-        this.colliderSet.raw.coSetMassProperties(
+        this.#colliderSet.raw.coSetMassProperties(
             this.handle,
             mass,
             rawCom,
@@ -501,7 +501,7 @@ export class Collider {
         principalAngularInertia: number,
     ) {
         let rawCom = VectorOps.intoRaw(centerOfMass);
-        this.colliderSet.raw.coSetMassProperties(
+        this.#colliderSet.raw.coSetMassProperties(
             this.handle,
             mass,
             rawCom,
@@ -519,10 +519,10 @@ export class Collider {
      */
     public setTranslation(tra: Vector) {
         // #if DIM2
-        this.colliderSet.raw.coSetTranslation(this.handle, tra.x, tra.y);
+        this.#colliderSet.raw.coSetTranslation(this.handle, tra.x, tra.y);
         // #endif
         // #if DIM3
-        this.colliderSet.raw.coSetTranslation(this.handle, tra.x, tra.y, tra.z);
+        this.#colliderSet.raw.coSetTranslation(this.handle, tra.x, tra.y, tra.z);
         // #endif
     }
 
@@ -535,14 +535,14 @@ export class Collider {
      */
     public setTranslationWrtParent(tra: Vector) {
         // #if DIM2
-        this.colliderSet.raw.coSetTranslationWrtParent(
+        this.#colliderSet.raw.coSetTranslationWrtParent(
             this.handle,
             tra.x,
             tra.y,
         );
         // #endif
         // #if DIM3
-        this.colliderSet.raw.coSetTranslationWrtParent(
+        this.#colliderSet.raw.coSetTranslationWrtParent(
             this.handle,
             tra.x,
             tra.y,
@@ -560,7 +560,7 @@ export class Collider {
      * @param rotation - The rotation to set.
      */
     public setRotation(rot: Rotation) {
-        this.colliderSet.raw.coSetRotation(
+        this.#colliderSet.raw.coSetRotation(
             this.handle,
             rot.x,
             rot.y,
@@ -578,7 +578,7 @@ export class Collider {
      * @param rotation - The rotation to set.
      */
     public setRotationWrtParent(rot: Rotation) {
-        this.colliderSet.raw.coSetRotationWrtParent(
+        this.#colliderSet.raw.coSetRotationWrtParent(
             this.handle,
             rot.x,
             rot.y,
@@ -595,7 +595,7 @@ export class Collider {
      * @param angle - The rotation angle, in radians.
      */
     public setRotation(angle: number) {
-        this.colliderSet.raw.coSetRotation(this.handle, angle);
+        this.#colliderSet.raw.coSetRotation(this.handle, angle);
     }
 
     /**
@@ -606,7 +606,7 @@ export class Collider {
      * @param angle - The rotation angle, in radians.
      */
     public setRotationWrtParent(angle: number) {
-        this.colliderSet.raw.coSetRotationWrtParent(this.handle, angle);
+        this.#colliderSet.raw.coSetRotationWrtParent(this.handle, angle);
     }
 
     // #endif
@@ -615,7 +615,7 @@ export class Collider {
      * The type of the shape of this collider.
      */
     public shapeType(): ShapeType {
-        return this.colliderSet.raw.coShapeType(
+        return this.#colliderSet.raw.coShapeType(
             this.handle,
         ) as number as ShapeType;
     }
@@ -625,7 +625,7 @@ export class Collider {
      */
     public halfExtents(): Vector {
         return VectorOps.fromRaw(
-            this.colliderSet.raw.coHalfExtents(this.handle),
+            this.#colliderSet.raw.coHalfExtents(this.handle),
         );
     }
 
@@ -636,14 +636,14 @@ export class Collider {
      */
     public setHalfExtents(newHalfExtents: Vector) {
         const rawPoint = VectorOps.intoRaw(newHalfExtents);
-        this.colliderSet.raw.coSetHalfExtents(this.handle, rawPoint);
+        this.#colliderSet.raw.coSetHalfExtents(this.handle, rawPoint);
     }
 
     /**
      * The radius of this collider if it is a ball, cylinder, capsule, or cone shape.
      */
     public radius(): number {
-        return this.colliderSet.raw.coRadius(this.handle);
+        return this.#colliderSet.raw.coRadius(this.handle);
     }
 
     /**
@@ -652,14 +652,14 @@ export class Collider {
      * @param newRadius - desired radius.
      */
     public setRadius(newRadius: number): void {
-        this.colliderSet.raw.coSetRadius(this.handle, newRadius);
+        this.#colliderSet.raw.coSetRadius(this.handle, newRadius);
     }
 
     /**
      * The radius of the round edges of this collider if it is a round cylinder.
      */
     public roundRadius(): number {
-        return this.colliderSet.raw.coRoundRadius(this.handle);
+        return this.#colliderSet.raw.coRoundRadius(this.handle);
     }
 
     /**
@@ -668,14 +668,14 @@ export class Collider {
      * @param newBorderRadius - desired round edge radius.
      */
     public setRoundRadius(newBorderRadius: number) {
-        this.colliderSet.raw.coSetRoundRadius(this.handle, newBorderRadius);
+        this.#colliderSet.raw.coSetRoundRadius(this.handle, newBorderRadius);
     }
 
     /**
      * The half height of this collider if it is a cylinder, capsule, or cone shape.
      */
     public halfHeight(): number {
-        return this.colliderSet.raw.coHalfHeight(this.handle);
+        return this.#colliderSet.raw.coHalfHeight(this.handle);
     }
 
     /**
@@ -684,7 +684,7 @@ export class Collider {
      * @param newHalfheight - desired half height.
      */
     public setHalfHeight(newHalfheight: number) {
-        this.colliderSet.raw.coSetHalfHeight(this.handle, newHalfheight);
+        this.#colliderSet.raw.coSetHalfHeight(this.handle, newHalfheight);
     }
 
     /**
@@ -706,7 +706,7 @@ export class Collider {
         // #endif
         filled: boolean,
     ) {
-        this.colliderSet.raw.coSetVoxel(
+        this.#colliderSet.raw.coSetVoxel(
             this.handle,
             ix,
             iy,
@@ -719,7 +719,7 @@ export class Collider {
         // up-to-date the next time the user requests the shape data.
         // PERF: this isn’t ideal for performances as this adds a
         //       hidden, non-constant, cost.
-        this._shape = null;
+        this.#_shape = null;
     }
 
     /**
@@ -753,7 +753,7 @@ export class Collider {
         shift_z: number,
         // #endif
     ) {
-        this.colliderSet.raw.coPropagateVoxelChange(
+        this.#colliderSet.raw.coPropagateVoxelChange(
             this.handle,
             voxels2.handle,
             ix,
@@ -771,7 +771,7 @@ export class Collider {
         // up-to-date the next time the user requests the shape data.
         // PERF: this isn’t ideal for performances as this adds a
         //       hidden, non-constant, cost.
-        this._shape = null;
+        this.#_shape = null;
     }
 
     /**
@@ -798,7 +798,7 @@ export class Collider {
         shift_z: number,
         // #endif
     ) {
-        this.colliderSet.raw.coCombineVoxelStates(
+        this.#colliderSet.raw.coCombineVoxelStates(
             this.handle,
             voxels2.handle,
             shift_x,
@@ -811,7 +811,7 @@ export class Collider {
         // up-to-date the next time the user requests the shape data.
         // PERF: this isn’t ideal for performances as this adds a
         //       hidden, non-constant, cost.
-        this._shape = null;
+        this.#_shape = null;
     }
 
     /**
@@ -819,7 +819,7 @@ export class Collider {
      * this returns the vertex buffer of said shape.
      */
     public vertices(): Float32Array {
-        return this.colliderSet.raw.coVertices(this.handle);
+        return this.#colliderSet.raw.coVertices(this.handle);
     }
 
     /**
@@ -827,7 +827,7 @@ export class Collider {
      * this returns the index buffer of said shape.
      */
     public indices(): Uint32Array | undefined {
-        return this.colliderSet.raw.coIndices(this.handle);
+        return this.#colliderSet.raw.coIndices(this.handle);
     }
 
     /**
@@ -836,7 +836,7 @@ export class Collider {
      * In 3D, the returned height matrix is provided in column-major order.
      */
     public heightfieldHeights(): Float32Array {
-        return this.colliderSet.raw.coHeightfieldHeights(this.handle);
+        return this.#colliderSet.raw.coHeightfieldHeights(this.handle);
     }
 
     /**
@@ -844,7 +844,7 @@ export class Collider {
      * applied to it.
      */
     public heightfieldScale(): Vector {
-        let scale = this.colliderSet.raw.coHeightfieldScale(this.handle);
+        let scale = this.#colliderSet.raw.coHeightfieldScale(this.handle);
         return VectorOps.fromRaw(scale);
     }
 
@@ -854,7 +854,7 @@ export class Collider {
      * rows of its height matrix.
      */
     public heightfieldNRows(): number {
-        return this.colliderSet.raw.coHeightfieldNRows(this.handle);
+        return this.#colliderSet.raw.coHeightfieldNRows(this.handle);
     }
 
     /**
@@ -862,7 +862,7 @@ export class Collider {
      * columns of its height matrix.
      */
     public heightfieldNCols(): number {
-        return this.colliderSet.raw.coHeightfieldNCols(this.handle);
+        return this.#colliderSet.raw.coHeightfieldNCols(this.handle);
     }
 
     // #endif
@@ -871,56 +871,56 @@ export class Collider {
      * The rigid-body this collider is attached to.
      */
     public parent(): RigidBody | null {
-        return this._parent;
+        return this.#_parent;
     }
 
     /**
      * The friction coefficient of this collider.
      */
     public friction(): number {
-        return this.colliderSet.raw.coFriction(this.handle);
+        return this.#colliderSet.raw.coFriction(this.handle);
     }
 
     /**
      * The restitution coefficient of this collider.
      */
     public restitution(): number {
-        return this.colliderSet.raw.coRestitution(this.handle);
+        return this.#colliderSet.raw.coRestitution(this.handle);
     }
 
     /**
      * The density of this collider.
      */
     public density(): number {
-        return this.colliderSet.raw.coDensity(this.handle);
+        return this.#colliderSet.raw.coDensity(this.handle);
     }
 
     /**
      * The mass of this collider.
      */
     public mass(): number {
-        return this.colliderSet.raw.coMass(this.handle);
+        return this.#colliderSet.raw.coMass(this.handle);
     }
 
     /**
      * The volume of this collider.
      */
     public volume(): number {
-        return this.colliderSet.raw.coVolume(this.handle);
+        return this.#colliderSet.raw.coVolume(this.handle);
     }
 
     /**
      * The collision groups of this collider.
      */
     public collisionGroups(): InteractionGroups {
-        return this.colliderSet.raw.coCollisionGroups(this.handle);
+        return this.#colliderSet.raw.coCollisionGroups(this.handle);
     }
 
     /**
      * The solver groups of this collider.
      */
     public solverGroups(): InteractionGroups {
-        return this.colliderSet.raw.coSolverGroups(this.handle);
+        return this.#colliderSet.raw.coSolverGroups(this.handle);
     }
 
     /**
@@ -930,7 +930,7 @@ export class Collider {
      */
     public containsPoint(point: Vector): boolean {
         let rawPoint = VectorOps.intoRaw(point);
-        let result = this.colliderSet.raw.coContainsPoint(
+        let result = this.#colliderSet.raw.coContainsPoint(
             this.handle,
             rawPoint,
         );
@@ -953,7 +953,7 @@ export class Collider {
     public projectPoint(point: Vector, solid: boolean): PointProjection | null {
         let rawPoint = VectorOps.intoRaw(point);
         let result = PointProjection.fromRaw(
-            this.colliderSet.raw.coProjectPoint(this.handle, rawPoint, solid),
+            this.#colliderSet.raw.coProjectPoint(this.handle, rawPoint, solid),
         );
 
         rawPoint.free();
@@ -971,7 +971,7 @@ export class Collider {
     public intersectsRay(ray: Ray, maxToi: number): boolean {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
-        let result = this.colliderSet.raw.coIntersectsRay(
+        let result = this.#colliderSet.raw.coIntersectsRay(
             this.handle,
             rawOrig,
             rawDir,
@@ -1017,8 +1017,8 @@ export class Collider {
         let rawShape2 = shape2.intoRaw();
 
         let result = ShapeCastHit.fromRaw(
-            this.colliderSet,
-            this.colliderSet.raw.coCastShape(
+            this.#colliderSet,
+            this.#colliderSet.raw.coCastShape(
                 this.handle,
                 rawCollider1Vel,
                 rawShape2,
@@ -1066,8 +1066,8 @@ export class Collider {
         let rawCollider2Vel = VectorOps.intoRaw(collider2Vel);
 
         let result = ColliderShapeCastHit.fromRaw(
-            this.colliderSet,
-            this.colliderSet.raw.coCastCollider(
+            this.#colliderSet,
+            this.#colliderSet.raw.coCastCollider(
                 this.handle,
                 rawCollider1Vel,
                 collider2.handle,
@@ -1093,7 +1093,7 @@ export class Collider {
         let rawRot2 = RotationOps.intoRaw(shapeRot2);
         let rawShape2 = shape2.intoRaw();
 
-        let result = this.colliderSet.raw.coIntersectsShape(
+        let result = this.#colliderSet.raw.coIntersectsShape(
             this.handle,
             rawShape2,
             rawPos2,
@@ -1127,7 +1127,7 @@ export class Collider {
         let rawShape2 = shape2.intoRaw();
 
         let result = ShapeContact.fromRaw(
-            this.colliderSet.raw.coContactShape(
+            this.#colliderSet.raw.coContactShape(
                 this.handle,
                 rawShape2,
                 rawPos2,
@@ -1155,7 +1155,7 @@ export class Collider {
         prediction: number,
     ): ShapeContact | null {
         let result = ShapeContact.fromRaw(
-            this.colliderSet.raw.coContactCollider(
+            this.#colliderSet.raw.coContactCollider(
                 this.handle,
                 collider2.handle,
                 prediction,
@@ -1180,7 +1180,7 @@ export class Collider {
     public castRay(ray: Ray, maxToi: number, solid: boolean): number {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
-        let result = this.colliderSet.raw.coCastRay(
+        let result = this.#colliderSet.raw.coCastRay(
             this.handle,
             rawOrig,
             rawDir,
@@ -1213,7 +1213,7 @@ export class Collider {
         let rawOrig = VectorOps.intoRaw(ray.origin);
         let rawDir = VectorOps.intoRaw(ray.dir);
         let result = RayIntersection.fromRaw(
-            this.colliderSet.raw.coCastRayAndGetNormal(
+            this.#colliderSet.raw.coCastRayAndGetNormal(
                 this.handle,
                 rawOrig,
                 rawDir,

--- a/src.ts/geometry/collider_set.ts
+++ b/src.ts/geometry/collider_set.ts
@@ -13,7 +13,7 @@ import {RigidBodySet} from "../dynamics";
  */
 export class ColliderSet {
     raw: RawColliderSet;
-    private map: Coarena<Collider>;
+    #map: Coarena<Collider>;
 
     /**
      * Release the WASM memory occupied by this collider set.
@@ -24,19 +24,19 @@ export class ColliderSet {
         }
         this.raw = undefined;
 
-        if (!!this.map) {
-            this.map.clear();
+        if (!!this.#map) {
+            this.#map.clear();
         }
-        this.map = undefined;
+        this.#map = undefined;
     }
 
     constructor(raw?: RawColliderSet) {
         this.raw = raw || new RawColliderSet();
-        this.map = new Coarena<Collider>();
+        this.#map = new Coarena<Collider>();
         // Initialize the map with the existing elements, if any.
         if (raw) {
             raw.forEachColliderHandle((handle: ColliderHandle) => {
-                this.map.set(handle, new Collider(this, handle, null));
+                this.#map.set(handle, new Collider(this, handle, null));
             });
         }
     }
@@ -56,7 +56,7 @@ export class ColliderSet {
 
     /** @internal */
     public finalizeDeserialization(bodies: RigidBodySet) {
-        this.map.forEach((collider) =>
+        this.#map.forEach((collider) =>
             collider.finalizeDeserialization(bodies),
         );
     }
@@ -139,7 +139,7 @@ export class ColliderSet {
 
         let parent = hasParent ? bodies.get(parentHandle) : null;
         let collider = new Collider(this, handle, parent, desc.shape);
-        this.map.set(handle, collider);
+        this.#map.set(handle, collider);
         return collider;
     }
 
@@ -165,7 +165,7 @@ export class ColliderSet {
      * @param handle
      */
     public unmap(handle: ImpulseJointHandle) {
-        this.map.delete(handle);
+        this.#map.delete(handle);
     }
 
     /**
@@ -174,14 +174,14 @@ export class ColliderSet {
      * @param handle - The handle of the rigid-body to retrieve.
      */
     public get(handle: ColliderHandle): Collider | null {
-        return this.map.get(handle);
+        return this.#map.get(handle);
     }
 
     /**
      * The number of colliders on this set.
      */
     public len(): number {
-        return this.map.len();
+        return this.#map.len();
     }
 
     /**
@@ -199,7 +199,7 @@ export class ColliderSet {
      * @param f - The closure to apply.
      */
     public forEach(f: (collider: Collider) => void) {
-        this.map.forEach(f);
+        this.#map.forEach(f);
     }
 
     /**
@@ -208,6 +208,6 @@ export class ColliderSet {
      * @returns collider list.
      */
     public getAll(): Collider[] {
-        return this.map.getAll();
+        return this.#map.getAll();
     }
 }


### PR DESCRIPTION
This PR reduces the bundle size using # for the private properties instead of the private keyword when the code is minified.

The results of `esbuild ./rapier.js --bundle --minify --target=esnext --format=esm --outfile=out.js`:

```
-a---          2025/10/23    19:36         112241 old.js
-a---          2025/10/23    20:12         111075 new.js
```

which is about 1.04% smaller. If you can find more private methods/property, It can be even smaller.

The principle is explained [here](https://github.com/honojs/hono/pull/3596).

The PR is tested on my own app.