### PR TITLE
Add contact modification physics hook support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,12 +338,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry2d",
  "rapier2d",
  "ref-cast",
  "serde",
@@ -352,12 +353,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-deterministic"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry2d",
  "rapier2d",
  "ref-cast",
  "serde",
@@ -366,12 +368,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier2d-simd"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry2d",
  "rapier2d",
  "ref-cast",
  "serde",
@@ -380,12 +383,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry3d",
  "rapier3d",
  "ref-cast",
  "serde",
@@ -394,12 +398,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-deterministic"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry3d",
  "rapier3d",
  "ref-cast",
  "serde",
@@ -408,12 +413,13 @@ dependencies = [
 
 [[package]]
 name = "dimforge_rapier3d-simd"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bincode",
  "js-sys",
  "nalgebra",
  "palette",
+ "parry3d",
  "rapier3d",
  "ref-cast",
  "serde",
@@ -578,9 +584,9 @@ checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
 name = "glam"
-version = "0.30.8"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12d847aeb25f41be4c0ec9587d624e9cd631bc007a8fd7ce3f5851e064c6460"
+checksum = "bd47b05dddf0005d850e5644cae7f2b14ac3df487979dbfff3b56f20b1a6ae46"
 
 [[package]]
 name = "globset"
@@ -796,7 +802,7 @@ dependencies = [
  "glam 0.27.0",
  "glam 0.28.0",
  "glam 0.29.3",
- "glam 0.30.8",
+ "glam 0.30.9",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -926,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ea16e5cdf52dd91b2a98ef781a2121f48dfb0880a92ae1ec6bc9e78097fceb"
+checksum = "ef681740349cec3ab9b5996b03b459b383b6998e1ffcb2804e8b57eb1e8491d9"
 dependencies = [
  "approx",
  "arrayvec",
@@ -955,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "parry3d"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2b4291e3c8fcba5f514ed627228c92fa4c94c38bb202c35be7b3b021090193"
+checksum = "e99471b7b6870f7fe406d5611dd4b4c9b07aa3e5436b1d27e1515f9832bb0c6b"
 dependencies = [
  "approx",
  "arrayvec",
@@ -966,7 +972,7 @@ dependencies = [
  "either",
  "ena",
  "foldhash 0.2.0",
- "glam 0.30.8",
+ "glam 0.30.9",
  "hashbrown 0.16.0",
  "indexmap",
  "log",

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -1,3 +1,4 @@
+import { RawVector } from "../raw";
 import { RigidBodyHandle } from "../dynamics";
 import { ColliderHandle } from "../geometry";
 import { Vector } from "../math";
@@ -20,7 +21,7 @@ export declare class ContactModificationContext {
     body1: RigidBodyHandle;
     body2: RigidBodyHandle;
 
-    normal: Vector;
+    normal: RawVector;
     user_data: number;
 
     num_solver_contacts(): number;
@@ -29,8 +30,8 @@ export declare class ContactModificationContext {
 
     remove_solver_contact(index: number): void;
 
-    solver_contact_point(index: number): Vector | null;
-    set_solver_contact_point(index: number, point: Vector): void;
+    solver_contact_point(index: number): RawVector | null;
+    set_solver_contact_point(index: number, point: RawVector): void;
 
     solver_contact_dist(index: number): number;
     set_solver_contact_dist(index: number, dist: number): void;
@@ -41,10 +42,10 @@ export declare class ContactModificationContext {
     solver_contact_restitution(index: number): number;
     set_solver_contact_restitution(index: number, restitution: number): void;
 
-    solver_contact_tangent_velocity(index: number): Vector | null;
+    solver_contact_tangent_velocity(index: number): RawVector | null;
     set_solver_contact_tangent_velocity(
         index: number,
-        tangent_velocity: Vector,
+        tangent_velocity: RawVector,
     ): void;
 
     solver_contact_warmstart_impulse(index: number): number;

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -1,17 +1,19 @@
-import {RigidBodyHandle} from "../dynamics";
-import {ColliderHandle} from "../geometry";
+import { RigidBodyHandle } from "../dynamics";
+import { ColliderHandle } from "../geometry";
 
 export enum ActiveHooks {
     NONE = 0,
     FILTER_CONTACT_PAIRS = 0b0001,
     FILTER_INTERSECTION_PAIRS = 0b0010,
-    // MODIFY_SOLVER_CONTACTS = 0b0100, /* Not supported yet in JS. */
+    MODIFY_SOLVER_CONTACTS = 0b0100,
 }
 
 export enum SolverFlags {
     EMPTY = 0b000,
     COMPUTE_IMPULSE = 0b001,
 }
+
+export type ContactModificationContext = any; // Placeholder for the actual ContactModificationContext type.
 
 export interface PhysicsHooks {
     /**
@@ -51,4 +53,15 @@ export interface PhysicsHooks {
         body1: RigidBodyHandle,
         body2: RigidBodyHandle,
     ): boolean;
+
+    /**
+     * Function that modifies the set of contacts seen by the constraints solver.
+     *
+     * Note that this method will only be called if at least one of the colliders
+     * involved in the contact contains the `ActiveHooks::MODIFY_SOLVER_CONTACTS` flags
+     * in its physics hooks flags.
+     *
+     * @param context - The context providing information and access to the contacts to modify.
+     */
+    modifySolverContacts(context: ContactModificationContext): void;
 }

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -1,5 +1,6 @@
 import { RigidBodyHandle } from "../dynamics";
 import { ColliderHandle } from "../geometry";
+import { Vector } from "../math";
 
 export enum ActiveHooks {
     NONE = 0,
@@ -13,7 +14,57 @@ export enum SolverFlags {
     COMPUTE_IMPULSE = 0b001,
 }
 
-export type ContactModificationContext = any; // Placeholder for the actual ContactModificationContext type.
+export declare class ContactModificationContext {
+    collider1: ColliderHandle;
+    collider2: ColliderHandle;
+    body1: RigidBodyHandle;
+    body2: RigidBodyHandle;
+
+    normal: Vector;
+    user_data: number;
+
+    num_solver_contacts(): number;
+
+    clear_solver_contacts(): void;
+
+    remove_solver_contact(index: number): void;
+
+    solver_contact_point(index: number): Vector | null;
+    set_solver_contact_point(index: number, point: Vector): void;
+
+    solver_contact_dist(index: number): number;
+    set_solver_contact_dist(index: number, dist: number): void;
+
+    solver_contact_friction(index: number): number;
+    set_solver_contact_friction(index: number, friction: number): void;
+
+    solver_contact_restitution(index: number): number;
+    set_solver_contact_restitution(index: number, restitution: number): void;
+
+    solver_contact_tangent_velocity(index: number): Vector | null;
+    set_solver_contact_tangent_velocity(
+        index: number,
+        tangent_velocity: Vector,
+    ): void;
+
+    solver_contact_warmstart_impulse(index: number): number;
+    set_solver_contact_warmstart_impulse(index: number, impulse: number): void;
+
+    solver_contact_warmstart_tangent_impulse(index: number): number;
+    set_solver_contact_warmstart_tangent_impulse(
+        index: number,
+        impulse: number,
+    ): void;
+
+    solver_contact_warmstart_twist_impulse(index: number): number;
+    set_solver_contact_warmstart_twist_impulse(
+        index: number,
+        impulse: number,
+    ): void;
+
+    solver_contact_is_new(index: number): boolean;
+    set_solver_contact_is_new(index: number, is_new: boolean): void;
+}
 
 export interface PhysicsHooks {
     /**

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -1,4 +1,4 @@
-import { RawVector } from "../raw";
+import { RawContactModificationContext } from "../raw";
 import { RigidBodyHandle } from "../dynamics";
 import { ColliderHandle } from "../geometry";
 import { Vector } from "../math";
@@ -13,58 +13,6 @@ export enum ActiveHooks {
 export enum SolverFlags {
     EMPTY = 0b000,
     COMPUTE_IMPULSE = 0b001,
-}
-
-export declare class ContactModificationContext {
-    collider1: ColliderHandle;
-    collider2: ColliderHandle;
-    body1: RigidBodyHandle;
-    body2: RigidBodyHandle;
-
-    normal: RawVector;
-    user_data: number;
-
-    num_solver_contacts(): number;
-
-    clear_solver_contacts(): void;
-
-    remove_solver_contact(index: number): void;
-
-    solver_contact_point(index: number): RawVector | null;
-    set_solver_contact_point(index: number, point: RawVector): void;
-
-    solver_contact_dist(index: number): number;
-    set_solver_contact_dist(index: number, dist: number): void;
-
-    solver_contact_friction(index: number): number;
-    set_solver_contact_friction(index: number, friction: number): void;
-
-    solver_contact_restitution(index: number): number;
-    set_solver_contact_restitution(index: number, restitution: number): void;
-
-    solver_contact_tangent_velocity(index: number): RawVector | null;
-    set_solver_contact_tangent_velocity(
-        index: number,
-        tangent_velocity: RawVector,
-    ): void;
-
-    solver_contact_warmstart_impulse(index: number): number;
-    set_solver_contact_warmstart_impulse(index: number, impulse: number): void;
-
-    solver_contact_warmstart_tangent_impulse(index: number): number;
-    set_solver_contact_warmstart_tangent_impulse(
-        index: number,
-        impulse: number,
-    ): void;
-
-    solver_contact_warmstart_twist_impulse(index: number): number;
-    set_solver_contact_warmstart_twist_impulse(
-        index: number,
-        impulse: number,
-    ): void;
-
-    solver_contact_is_new(index: number): boolean;
-    set_solver_contact_is_new(index: number, is_new: boolean): void;
 }
 
 export interface PhysicsHooks {
@@ -115,5 +63,5 @@ export interface PhysicsHooks {
      *
      * @param context - The context providing information and access to the contacts to modify.
      */
-    modifySolverContacts(context: ContactModificationContext): void;
+    modifySolverContacts(context: RawContactModificationContext): void;
 }

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -1,7 +1,7 @@
-import { RawContactModificationContext } from "../raw";
+import { RawContactManifold, RawContactModificationContext } from "../raw";
 import { RigidBodyHandle } from "../dynamics";
 import { ColliderHandle } from "../geometry";
-import { Vector } from "../math";
+import { Vector, VectorOps } from "../math";
 
 export enum ActiveHooks {
     NONE = 0,
@@ -13,6 +13,294 @@ export enum ActiveHooks {
 export enum SolverFlags {
     EMPTY = 0b000,
     COMPUTE_IMPULSE = 0b001,
+}
+
+export class ContactModificationContext {
+    raw: RawContactModificationContext;
+    constructor(raw: RawContactModificationContext) {
+        this.raw = raw;
+    }
+
+    /**
+     * Collider handle of the first collider involved in this contact modification context.
+     */
+    get collider1(): ColliderHandle {
+        return this.raw.collider1();
+    }
+
+    /**
+     * Collider handle of the second collider involved in this contact modification context.
+     */
+    get collider2(): ColliderHandle {
+        return this.raw.collider2();
+    }
+
+    /**
+     * Rigid body handle of the first rigid body involved in this contact modification context.
+     */
+    get rigidBody1(): RigidBodyHandle | undefined {
+        return this.raw.rigid_body1();
+    }
+
+    /**
+     * Rigid body handle of the second rigid body involved in this contact modification context.
+     */
+    get rigidBody2(): RigidBodyHandle | undefined {
+        return this.raw.rigid_body2();
+    }
+
+    /**
+     * Normal of the contact in this context.
+     */
+    get normal(): Vector {
+        return VectorOps.fromRaw(this.raw.normal);
+    }
+
+    set normal(v: Vector) {
+        this.raw.normal = VectorOps.intoRaw(v);
+    }
+
+    /**
+     * User data associated with this contact.
+     */
+    get userData(): number {
+        return this.raw.user_data();
+    }
+
+    set userData(data: number) {
+        this.raw.user_data = data;
+    }
+
+    /**
+     * Number of solver contacts in this contact modification context.
+     */
+    get numSolverContacts(): number {
+        return this.raw.num_solver_contacts();
+    }
+
+    /**
+     * Clears all the solver contacts in this contact modification context.
+     */
+    clearSolverContacts(): void {
+        this.raw.clear_solver_contacts();
+    }
+
+    /**
+     * Removes the solver contact at the given index. The last solver contact
+     * will be moved to the given index.
+     * @param index - The index of the solver contact to remove.
+     */
+    removeSolverContact(index: number): void {
+        this.raw.remove_solver_contact(index);
+    }
+
+    /**
+     * Gets the location of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @returns The location of the solver contact, in world-space coordinates.
+     */
+    getSolverContactPoint(index: number): Vector {
+        return VectorOps.fromRaw(this.raw.solver_contact_point(index));
+    }
+
+    /**
+     * Sets the location of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @param point - The new location of the solver contact, in world-space coordinates.
+     */
+    setSolverContactPoint(index: number, point: Vector): void {
+        this.raw.set_solver_contact_point(index, VectorOps.intoRaw(point));
+    }
+
+    /**
+     * Gets the distance between the two original contacts points along the contact normal.
+     * @param index - The index of the solver contact.
+     * @returns The distance between the two original contacts points along the contact normal.
+     */
+    getSolverContactDist(index: number): number {
+        return this.raw.solver_contact_dist(index);
+    }
+
+    /**
+     * Modifies the distance between the two original contacts points along the contact normal.
+     * @param index - The index of the solver contact.
+     * @param dist - The new distance between the two original contacts points along the contact normal.
+     */
+    setSolverContactDist(index: number, dist: number): void {
+        this.raw.set_solver_contact_dist(index, dist);
+    }
+
+    /**
+     * Gets the effective friction of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @returns The friction of the solver contact.
+     */
+    getSolverContactFriction(index: number): number {
+        return this.raw.solver_contact_friction(index);
+    }
+
+    /**
+     * Sets the effective friction of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @param friction - The new friction of the solver contact.
+     */
+    setSolverContactFriction(index: number, friction: number): void {
+        this.raw.set_solver_contact_friction(index, friction);
+    }
+
+    /**
+     * Gets the effective restitution of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @returns The restitution of the solver contact.
+     */
+    getSolverContactRestitution(index: number): number {
+        return this.raw.solver_contact_restitution(index);
+    }
+
+    /**
+     * Sets the effective restitution of the solver contact at the given index.
+     * @param index - The index of the solver contact.
+     * @param restitution - The new restitution of the solver contact.
+     */
+    setSolverContactRestitution(index: number, restitution: number): void {
+        this.raw.set_solver_contact_restitution(index, restitution);
+    }
+
+    /**
+     * Gets the tangent velocity of the solver contact at the given index. This
+     * is set to zero by default. It can be used to simulate conveyor belts or
+     * similar effects.
+     * @param index - The index of the solver contact.
+     * @returns The tangent velocity of the solver contact.
+     */
+    getSolverContactTangentVelocity(index: number): Vector {
+        return VectorOps.fromRaw(
+            this.raw.solver_contact_tangent_velocity(index),
+        );
+    }
+
+    /**
+     * Sets the tangent velocity of the solver contact at the given index. This
+     * is set to zero by default. It can be used to simulate conveyor belts or
+     * similar effects.
+     * @param index - The index of the solver contact.
+     * @param tangentVelocity - The new tangent velocity of the solver contact.
+     */
+    setSolverContactTangentVelocity(
+        index: number,
+        tangentVelocity: Vector,
+    ): void {
+        this.raw.set_solver_contact_tangent_velocity(
+            index,
+            VectorOps.intoRaw(tangentVelocity),
+        );
+    }
+
+    /**
+     * Gets the impulse used to warmstart the solve for the normal constraint.
+     * @param index - The index of the solver contact.
+     * @returns Impulse used to warmstart the solve for the normal constraint.
+     */
+    getSolverContactWarmstartImpulse(index: number): number {
+        return this.raw.solver_contact_warmstart_impulse(index);
+    }
+
+    /**
+     * Sets the impulse used to warmstart the solve for the normal constraint.
+     * @param index - The index of the solver contact.
+     * @param impulse - New impulse to warmstart the solve for the normal constraint.
+     */
+    setSolverContactWarmstartImpulse(index: number, impulse: number): void {
+        this.raw.set_solver_contact_warmstart_impulse(index, impulse);
+    }
+
+    /**
+     * Gets the impulse used to warmstart the solve for the friction constraints.
+     * @param index - The index of the solver contact.
+     * @returns Impulse used to warmstart the solve for the friction constraints.
+     */
+    getSolverContactWarmstartTangentImpulse(index: number): number {
+        return this.raw.solver_contact_warmstart_tangent_impulse(index);
+    }
+
+    /**
+     * Sets the impulse used to warmstart the solve for the friction constraints.
+     * @param index - The index of the solver contact.
+     * @param impulse - New impulse to warmstart the solve for the friction constraints.
+     */
+    setSolverContactWarmstartTangentImpulse(
+        index: number,
+        impulse: number,
+    ): void {
+        this.raw.set_solver_contact_warmstart_tangent_impulse(index, impulse);
+    }
+
+    /**
+     * Gets the impulse used to warmstart the solve for the twist friction constraints.
+     * @param index - The index of the solver contact.
+     * @returns Impulse used to warmstart the solve for the twist friction constraints.
+     */
+    getSolverContactWarmstartTwistImpulse(index: number): number {
+        return this.raw.solver_contact_warmstart_twist_impulse(index);
+    }
+
+    /**
+     * Sets the impulse used to warmstart the solve for the twist friction constraints.
+     * @param index - The index of the solver contact.
+     * @param impulse New impulse to warmstart the solve for the twist friction constraints.
+     */
+    setSolverContactWarmstartTwistImpulse(
+        index: number,
+        impulse: number,
+    ): void {
+        this.raw.set_solver_contact_warmstart_twist_impulse(index, impulse);
+    }
+
+    /**
+     * @param index - The index of the solver contact.
+     * @returns Whether this contact existed during the last timestep.
+     */
+    getSolverContactIsNew(index: number): boolean {
+        return this.raw.solver_contact_is_new(index);
+    }
+
+    /**
+     * Sets whether this contact existed during the last timestep.
+     * @param index - The index of the solver contact.
+     * @param isNew - Whether this contact is new.
+     */
+    setSolverContactIsNew(index: number, isNew: boolean): void {
+        this.raw.set_solver_contact_is_new(index, isNew);
+    }
+
+    /**
+     * Returns the contact manifold associated with this contact modification context.
+     *
+     * Can be used with TempContactManifold methods for easier use.
+     */
+    get contactManifold(): RawContactManifold {
+        return this.raw.contact_manifold();
+    }
+
+    /**
+     * Helper function to update `self` to emulate a oneway-platform.
+     * The "oneway" behavior will only allow contacts between two colliders
+     * if the local contact normal of the first collider involved in the contact
+     * is almost aligned with the provided `allowed_local_n1` direction.
+     *
+     * To make this method work properly it must be called as part of the
+     * `PhysicsHooks::modifySolverContacts` method at each timestep, for each
+     * contact manifold involving a one-way platform. The `self.userData` field
+     * must not be modified from the outside of this method.
+     * @param allowedLocalN1 - The allowed contact normal direction in the local space of the first collider.
+     * @param allowedAngle - The maximum angle (in radians) between the contact normal and the `allowed_local_n1` direction.
+     */
+    updateAsOnewayPlatform(allowedLocalN1: Vector, allowedAngle: number): void {
+        this.raw.update_as_oneway_platform(
+            VectorOps.intoRaw(allowedLocalN1),
+            allowedAngle,
+        );
+    }
 }
 
 export interface PhysicsHooks {

--- a/src.ts/pipeline/physics_hooks.ts
+++ b/src.ts/pipeline/physics_hooks.ts
@@ -64,7 +64,7 @@ export class ContactModificationContext {
      * User data associated with this contact.
      */
     get userData(): number {
-        return this.raw.user_data();
+        return this.raw.user_data;
     }
 
     set userData(data: number) {
@@ -279,7 +279,7 @@ export class ContactModificationContext {
      * Can be used with TempContactManifold methods for easier use.
      */
     get contactManifold(): RawContactManifold {
-        return this.raw.contact_manifold();
+        return this.raw.contact_manifold;
     }
 
     /**
@@ -349,7 +349,8 @@ export interface PhysicsHooks {
      * involved in the contact contains the `ActiveHooks::MODIFY_SOLVER_CONTACTS` flags
      * in its physics hooks flags.
      *
-     * @param context - The context providing information and access to the contacts to modify.
+     * @param context - The raw context providing information and access to the contacts to modify.
+     * Can be used with ContactModificationContext for easier use.
      */
-    modifySolverContacts(context: RawContactModificationContext): void;
+    modifySolverContacts?(context: RawContactModificationContext): void;
 }

--- a/src.ts/pipeline/physics_pipeline.ts
+++ b/src.ts/pipeline/physics_pipeline.ts
@@ -1,13 +1,13 @@
-import {RawPhysicsPipeline} from "../raw";
-import {Vector, VectorOps} from "../math";
+import { RawPhysicsPipeline } from "../raw";
+import { Vector, VectorOps } from "../math";
 import {
-    IntegrationParameters,
+    CCDSolver,
     ImpulseJointSet,
+    IntegrationParameters,
+    IslandManager,
     MultibodyJointSet,
     RigidBodyHandle,
     RigidBodySet,
-    CCDSolver,
-    IslandManager,
 } from "../dynamics";
 import {
     BroadPhase,
@@ -15,8 +15,8 @@ import {
     ColliderSet,
     NarrowPhase,
 } from "../geometry";
-import {EventQueue} from "./event_queue";
-import {PhysicsHooks} from "./physics_hooks";
+import { EventQueue } from "./event_queue";
+import { PhysicsHooks } from "./physics_hooks";
 
 export class PhysicsPipeline {
     raw: RawPhysicsPipeline;
@@ -64,6 +64,7 @@ export class PhysicsPipeline {
                 hooks,
                 !!hooks ? hooks.filterContactPair : null,
                 !!hooks ? hooks.filterIntersectionPair : null,
+                !!hooks ? hooks.modifySolverContacts : null,
             );
         } else {
             this.raw.step(

--- a/src/geometry/narrow_phase.rs
+++ b/src/geometry/narrow_phase.rs
@@ -62,7 +62,7 @@ impl RawNarrowPhase {
 #[wasm_bindgen]
 pub struct RawContactPair(*const ContactPair);
 #[wasm_bindgen]
-pub struct RawContactManifold(*const ContactManifold);
+pub struct RawContactManifold(pub(crate) *const ContactManifold);
 
 // SAFETY: the use of a raw pointer is very unsafe.
 //         We need this because wasm-bindgen doesn't support

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -1,3 +1,4 @@
+use crate::geometry::RawContactManifold;
 use crate::math::RawVector;
 use crate::utils::{self, FlatHandle};
 use rapier::geometry::SolverFlags;
@@ -107,12 +108,21 @@ pub struct RawContactModificationContext {
 
 #[wasm_bindgen]
 impl RawContactModificationContext {
+    // Simple getters and setters for the fields.
     pub fn collider1(&self) -> FlatHandle {
         self.collider1
     }
 
     pub fn collider2(&self) -> FlatHandle {
         self.collider2
+    }
+
+    pub fn rigid_body1(&self) -> Option<FlatHandle> {
+        self.rigid_body1
+    }
+
+    pub fn rigid_body2(&self) -> Option<FlatHandle> {
+        self.rigid_body2
     }
 
     #[wasm_bindgen(getter)]
@@ -139,6 +149,7 @@ impl RawContactModificationContext {
         }
     }
 
+    // Solver contacts manipulation methods.
     pub fn num_solver_contacts(&self) -> usize {
         unsafe { (*self.solver_contacts).len() }
     }
@@ -222,5 +233,58 @@ impl RawContactModificationContext {
                 c.tangent_velocity = vel.0.into()
             }
         }
+    }
+
+    pub fn solver_contact_warmstart_impulse(&self, i: usize) -> Real {
+        unsafe { (&(*self.solver_contacts))[i].warmstart_impulse }
+    }
+
+    pub fn set_solver_contact_warmstart_impulse(&mut self, i: usize, impulse: Real) {
+        unsafe {
+            if let Some(c) = (&mut (*self.solver_contacts)).get_mut(i) {
+                c.warmstart_impulse = impulse
+            }
+        }
+    }
+
+    pub fn solver_contact_warmstart_tangent_impulse(&self, i: usize) -> Real {
+        unsafe { (&(*self.solver_contacts))[i].warmstart_tangent_impulse.x }
+    }
+
+    pub fn set_solver_contact_warmstart_tangent_impulse(&mut self, i: usize, impulse: Real) {
+        unsafe {
+            if let Some(c) = (&mut (*self.solver_contacts)).get_mut(i) {
+                c.warmstart_tangent_impulse.x = impulse;
+            }
+        }
+    }
+
+    pub fn solver_contact_warmstart_twist_impulse(&self, i: usize) -> Real {
+        unsafe { (&(*self.solver_contacts))[i].warmstart_twist_impulse }
+    }
+
+    pub fn set_solver_contact_warmstart_twist_impulse(&mut self, i: usize, impulse: Real) {
+        unsafe {
+            if let Some(c) = (&mut (*self.solver_contacts)).get_mut(i) {
+                c.warmstart_twist_impulse = impulse
+            }
+        }
+    }
+
+    pub fn solver_contact_is_new(&self, i: usize) -> bool {
+        unsafe { (&(*self.solver_contacts))[i].is_new == 1.0 }
+    }
+
+    pub fn set_solver_contact_is_new(&mut self, i: usize, is_new: bool) {
+        unsafe {
+            if let Some(c) = (&mut (*self.solver_contacts)).get_mut(i) {
+                c.is_new = if is_new { 1.0 } else { 0.0 };
+            }
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn contact_manifold(&self) -> RawContactManifold {
+        RawContactManifold(self.manifold)
     }
 }

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -131,9 +131,9 @@ impl RawContactModificationContext {
     }
 
     #[wasm_bindgen(setter)]
-    pub fn set_normal(&mut self, normal: RawVector) {
+    pub fn set_normal(&mut self, normal: &RawVector) {
         unsafe {
-            *self.normal = normal.0;
+            *self.normal = normal.0.into();
         }
     }
 

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -141,6 +141,7 @@ impl RawPhysicsPipeline {
         hookObject: js_sys::Object,
         hookFilterContactPair: js_sys::Function,
         hookFilterIntersectionPair: js_sys::Function,
+        hookModifySolverContacts: js_sys::Function,
     ) {
         if eventQueue.auto_drain {
             eventQueue.clear();
@@ -150,6 +151,7 @@ impl RawPhysicsPipeline {
             this: hookObject,
             filter_contact_pair: hookFilterContactPair,
             filter_intersection_pair: hookFilterIntersectionPair,
+            modify_solver_contacts: hookModifySolverContacts,
         };
 
         self.0.step(

--- a/src/pipeline/physics_pipeline.rs
+++ b/src/pipeline/physics_pipeline.rs
@@ -141,7 +141,7 @@ impl RawPhysicsPipeline {
         hookObject: js_sys::Object,
         hookFilterContactPair: js_sys::Function,
         hookFilterIntersectionPair: js_sys::Function,
-        hookModifySolverContacts: js_sys::Function,
+        hookModifySolverContacts: Option<js_sys::Function>,
     ) {
         if eventQueue.auto_drain {
             eventQueue.clear();

--- a/testbed2d/src/Testbed.ts
+++ b/testbed2d/src/Testbed.ts
@@ -49,8 +49,9 @@ export class Testbed {
     inhibitLookAt: boolean;
     parameters: SimulationParameters;
     demoToken: number;
-    mouse: {x: number; y: number};
+    mouse: { x: number; y: number };
     events: RAPIER.EventQueue;
+    hooks: RAPIER.PhysicsHooks;
     world: RAPIER.World;
     preTimestepAction?: (gfx: Graphics) => void;
     stepId: number;
@@ -68,7 +69,7 @@ export class Testbed {
         this.inhibitLookAt = false;
         this.parameters = parameters;
         this.demoToken = 0;
-        this.mouse = {x: 0, y: 0};
+        this.mouse = { x: 0, y: 0 };
         this.events = new RAPIER.EventQueue(true);
         this.switchToDemo(builders.keys().next().value);
 
@@ -146,7 +147,7 @@ export class Testbed {
             }
 
             let t0 = new Date().getTime();
-            this.world.step(this.events);
+            this.world.step(this.events, this.hooks);
             this.gui.setTiming(new Date().getTime() - t0);
             this.stepId += 1;
 

--- a/testbed2d/src/demos/oneWayPlatforms.ts
+++ b/testbed2d/src/demos/oneWayPlatforms.ts
@@ -1,0 +1,125 @@
+import { Graphics } from "../Graphics";
+import type { Testbed } from "../Testbed";
+
+type RAPIER_API = typeof import("@dimforge/rapier2d");
+
+export function initWorld(RAPIER: RAPIER_API, testbed: Testbed) {
+    const physics_hooks = {
+        filterContactPair() {
+            return RAPIER.SolverFlags.COMPUTE_IMPULSE;
+        },
+        filterIntersectionPair() {
+            return true;
+        },
+        modifySolverContacts: (
+            context: any,
+        ) => {
+            let allowed_local_n1 = { x: 0.0, y: 0.0 };
+
+            if (context.collider1() == platform1Collider.handle) {
+                allowed_local_n1 = { x: 0.0, y: 1.0 };
+            } else if (context.collider2() == platform1Collider.handle) {
+                // Flip the allowed direction.
+                allowed_local_n1 = { x: 0.0, y: -1.0 };
+            }
+
+            if (context.collider1() == platform2Collider.handle) {
+                allowed_local_n1 = { x: 0.0, y: -1.0 };
+            } else if (context.collider2() == platform2Collider.handle) {
+                // Flip the allowed direction.
+                allowed_local_n1 = { x: 0.0, y: 1.0 };
+            }
+
+            // Call the helper function that simulates one-way platforms.
+            context.update_as_oneway_platform(
+                RAPIER.VectorOps.intoRaw(allowed_local_n1),
+                0.1,
+            );
+
+            // Set the surface velocity of the accepted contacts.
+            let tangent_velocity =
+                (context.collider1() == platform1Collider.handle ||
+                        context.collider2() == platform2Collider.handle)
+                    ? -12.0
+                    : 12.0;
+
+            for (let i = 0; i < context.num_solver_contacts(); ++i) {
+                context.set_solver_contact_tangent_velocity(
+                    i,
+                    RAPIER.VectorOps.intoRaw({
+                        x: tangent_velocity,
+                        y: 0.0,
+                    }),
+                );
+            }
+        },
+    };
+
+    let gravity = new RAPIER.Vector2(0.0, -9.81);
+    let world = new RAPIER.World(gravity);
+
+    let groundBody = RAPIER.RigidBodyDesc.fixed().setTranslation(0.0, 0.0);
+    let groundHandle = world.createRigidBody(groundBody);
+
+    let platform1 = RAPIER.ColliderDesc.cuboid(25.0, 0.5)
+        .setTranslation(30.0, 2.0)
+        .setActiveHooks(RAPIER.ActiveHooks.MODIFY_SOLVER_CONTACTS);
+    let platform1Collider = world.createCollider(platform1, groundHandle);
+
+    let platform2 = RAPIER.ColliderDesc.cuboid(25.0, 0.5)
+        .setTranslation(-30.0, -2.0)
+        .setActiveHooks(RAPIER.ActiveHooks.MODIFY_SOLVER_CONTACTS);
+    let platform2Collider = world.createCollider(platform2, groundHandle);
+
+    // Note: The OneWayPlatformHook implementation is omitted for brevity.
+    // let physicsHooks = new OneWayPlatformHook(/* platform1, platform2 */);
+
+    let boxCollDesc = RAPIER.ColliderDesc.cuboid(1.5, 2.0);
+    let boxBodyDesc = RAPIER.RigidBodyDesc.dynamic().setTranslation(
+        20.0,
+        10.0,
+    );
+    let box0 = world.createRigidBody(boxBodyDesc);
+    world.createCollider(
+        boxCollDesc,
+        box0,
+    );
+    let box1 = world.createRigidBody(
+        boxBodyDesc.setTranslation(40.0, -10.0).setGravityScale(-1),
+    );
+    world.createCollider(
+        boxCollDesc,
+        box1,
+    );
+    let box2 = world.createRigidBody(
+        boxBodyDesc.setTranslation(-20.0, 10.0).setGravityScale(1),
+    );
+    world.createCollider(
+        boxCollDesc,
+        box2,
+    );
+    let box3 = world.createRigidBody(
+        boxBodyDesc.setTranslation(-40.0, -10.0).setGravityScale(-1),
+    );
+    world.createCollider(
+        boxCollDesc,
+        box3,
+    );
+
+    testbed.hooks = physics_hooks;
+    testbed.setpreTimestepAction((graphics: Graphics) => {
+        testbed.world.forEachActiveRigidBody((body) => {
+            if (body.translation().y > 1.0) {
+                body.setGravityScale(1.0, false);
+            } else if (body.translation().y < -1.0) {
+                body.setGravityScale(-1.0, false);
+            }
+        });
+    });
+
+    testbed.setWorld(world);
+    testbed.lookAt({
+        target: { x: -10.0, y: -30.0 },
+        zoom: 7.0,
+    });
+}

--- a/testbed2d/src/demos/oneWayPlatforms.ts
+++ b/testbed2d/src/demos/oneWayPlatforms.ts
@@ -12,44 +12,45 @@ export function initWorld(RAPIER: RAPIER_API, testbed: Testbed) {
             return true;
         },
         modifySolverContacts: (
-            context: any,
+            rawContext: any,
         ) => {
+            const context = new RAPIER.ContactModificationContext(rawContext);
             let allowed_local_n1 = { x: 0.0, y: 0.0 };
 
-            if (context.collider1() == platform1Collider.handle) {
+            if (context.collider1 == platform1Collider.handle) {
                 allowed_local_n1 = { x: 0.0, y: 1.0 };
-            } else if (context.collider2() == platform1Collider.handle) {
+            } else if (context.collider2 == platform1Collider.handle) {
                 // Flip the allowed direction.
                 allowed_local_n1 = { x: 0.0, y: -1.0 };
             }
 
-            if (context.collider1() == platform2Collider.handle) {
+            if (context.collider1 == platform2Collider.handle) {
                 allowed_local_n1 = { x: 0.0, y: -1.0 };
-            } else if (context.collider2() == platform2Collider.handle) {
+            } else if (context.collider2 == platform2Collider.handle) {
                 // Flip the allowed direction.
                 allowed_local_n1 = { x: 0.0, y: 1.0 };
             }
 
             // Call the helper function that simulates one-way platforms.
-            context.update_as_oneway_platform(
-                RAPIER.VectorOps.intoRaw(allowed_local_n1),
+            context.updateAsOnewayPlatform(
+                allowed_local_n1,
                 0.1,
             );
 
             // Set the surface velocity of the accepted contacts.
             let tangent_velocity =
-                (context.collider1() == platform1Collider.handle ||
-                        context.collider2() == platform2Collider.handle)
+                (context.collider1 == platform1Collider.handle ||
+                        context.collider2 == platform2Collider.handle)
                     ? -12.0
                     : 12.0;
 
-            for (let i = 0; i < context.num_solver_contacts(); ++i) {
-                context.set_solver_contact_tangent_velocity(
+            for (let i = 0; i < context.numSolverContacts; ++i) {
+                context.setSolverContactTangentVelocity(
                     i,
-                    RAPIER.VectorOps.intoRaw({
+                    {
                         x: tangent_velocity,
                         y: 0.0,
-                    }),
+                    },
                 );
             }
         },

--- a/testbed2d/src/index.ts
+++ b/testbed2d/src/index.ts
@@ -1,4 +1,4 @@
-import {Testbed} from "./Testbed";
+import { Testbed } from "./Testbed";
 import * as CollisionGroups from "./demos/collisionGroups";
 import * as Cubes from "./demos/cubes";
 import * as Keva from "./demos/keva";
@@ -9,6 +9,7 @@ import * as LockedRotations from "./demos/lockedRotations";
 import * as ConvexPolygons from "./demos/convexPolygons";
 import * as CharacterController from "./demos/characterController";
 import * as PidController from "./demos/pidController";
+import * as OneWayPlatforms from "./demos/oneWayPlatforms";
 import * as Voxels from "./demos/voxels";
 
 import("@dimforge/rapier2d").then((RAPIER) => {
@@ -21,6 +22,7 @@ import("@dimforge/rapier2d").then((RAPIER) => {
         ["joints: revolute", RevoluteJoints.initWorld],
         ["keva tower", Keva.initWorld],
         ["locked rotations", LockedRotations.initWorld],
+        ["one way platforms", OneWayPlatforms.initWorld],
         ["pid controller", PidController.initWorld],
         ["polyline", Polyline.initWorld],
         ["voxels", Voxels.initWorld],


### PR DESCRIPTION
I recently had the need to use contact modification in Javascript, and I noticed it's not supported.

I've uncommented the implementation already there and cleaned it up a little. From a little testing, it seems to work exactly as expected. I've noticed a few elements (rigid body/contact manifold) are missing from the original implementation code and will add those in. What else is needed to get this merged in?