### PR TITLE
fix: update wasm-bindgen to 0.2.109 for CSP compatibility

### DIFF
--- a/builds/prepare_builds/templates/Cargo.toml.tera
+++ b/builds/prepare_builds/templates/Cargo.toml.tera
@@ -38,7 +38,7 @@ rapier{{ dimension }}d = { version = "0.30.1", features = [
 # The explicit dependency to parry only needed to pin the patch version.
 parry{{ dimension }}d = { version = "^0.25.3" }
 ref-cast = "1"
-wasm-bindgen = "0.2.100"
+wasm-bindgen = "0.2.109"
 js-sys = "0.3"
 nalgebra = "0.34"
 serde = { version = "1", features = ["derive", "rc"] }


### PR DESCRIPTION
## Summary

Update `wasm-bindgen` from `0.2.100` to `0.2.109` in the Cargo.toml template to remove the `new Function()` fallback that requires `'unsafe-eval'` in CSP.

## Problem

The current JS glue code generated by `wasm-bindgen` 0.2.100 includes:

```javascript
imports.wbg.__wbg_newnoargs = function(arg0, arg1) {
    const ret = new Function(getStringFromWasm0(arg0, arg1));
    return addHeapObject(ret);
};
```

This forces applications to allow `'unsafe-eval'` in their Content-Security-Policy `script-src` directive, which is a significant security downgrade — it permits arbitrary `eval()` and `new Function()` calls.

## Solution

`wasm-bindgen` 0.2.109 ([PR #4910](https://github.com/wasm-bindgen/wasm-bindgen/pull/4910)) removed the `new Function("return this")` fallback entirely in favor of `globalThis`, which is supported in all modern browsers.

This is a one-line change to `builds/prepare_builds/templates/Cargo.toml.tera`. After rebuilding, applications can use the much safer `'wasm-unsafe-eval'` (which only permits WebAssembly compilation) instead of `'unsafe-eval'`.

## Notes

- Only the template is changed. `Cargo.lock` will be updated automatically during the next `wasm-pack build`.
- `globalThis` browser support: Chrome 71+, Firefox 65+, Safari 12.1+ ([caniuse](https://caniuse.com/mdn-javascript_builtins_globalthis))

Closes #366