### PR TITLE
feat: Add frame setter methods for revolute/prismatic joints

### DIFF
--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -210,6 +210,48 @@ export class ImpulseJoint {
         rawPoint.free();
     }
 
+    // #if DIM3
+    /**
+     * Sets the rotation quaternion that aligns this joint's first local axis to the `x` axis.
+     */
+    public setFrameX1(rot: Rotation) {
+        const rawRot = RotationOps.intoRaw(rot);
+        this.rawSet.jointSetFrameX1(this.handle, rawRot);
+        rawRot.free();
+    }
+
+    /**
+     * Sets the rotation quaternion that aligns this joint's second local axis to the `x` axis.
+     */
+    public setFrameX2(rot: Rotation) {
+        const rawRot = RotationOps.intoRaw(rot);
+        this.rawSet.jointSetFrameX2(this.handle, rawRot);
+        rawRot.free();
+    }
+
+    /**
+     * Sets the full local frame (anchor position and rotation) for the first rigid-body attachment.
+     */
+    public setLocalFrame1(anchor: Vector, rot: Rotation) {
+        const rawAnchor = VectorOps.intoRaw(anchor);
+        const rawRot = RotationOps.intoRaw(rot);
+        this.rawSet.jointSetLocalFrame1(this.handle, rawAnchor, rawRot);
+        rawAnchor.free();
+        rawRot.free();
+    }
+
+    /**
+     * Sets the full local frame (anchor position and rotation) for the second rigid-body attachment.
+     */
+    public setLocalFrame2(anchor: Vector, rot: Rotation) {
+        const rawAnchor = VectorOps.intoRaw(anchor);
+        const rawRot = RotationOps.intoRaw(rot);
+        this.rawSet.jointSetLocalFrame2(this.handle, rawAnchor, rawRot);
+        rawAnchor.free();
+        rawRot.free();
+    }
+    // #endif
+
     /**
      * Controls whether contacts are computed between colliders attached
      * to the rigid-bodies linked by this joint.

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -2,6 +2,7 @@ use crate::dynamics::{RawImpulseJointSet, RawJointAxis, RawJointType, RawMotorMo
 use crate::math::{RawRotation, RawVector};
 use crate::utils::{self, FlatHandle};
 use rapier::dynamics::JointAxis;
+use rapier::math::Isometry;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -59,6 +60,34 @@ impl RawImpulseJointSet {
         self.map_mut(handle, |j| {
             j.data.set_local_anchor2(newPos.0.into());
         })
+    }
+
+    /// Sets the angular part of the joint's local frame relative to the first rigid-body.
+    pub fn jointSetFrameX1(&mut self, handle: FlatHandle, newRot: &RawRotation) {
+        self.map_mut(handle, |j| {
+            j.data.local_frame1.rotation = newRot.0;
+        });
+    }
+
+    /// Sets the angular part of the joint's local frame relative to the second rigid-body.
+    pub fn jointSetFrameX2(&mut self, handle: FlatHandle, newRot: &RawRotation) {
+        self.map_mut(handle, |j| {
+            j.data.local_frame2.rotation = newRot.0;
+        });
+    }
+
+    /// Sets the full local frame (anchor + rotation) for the first rigid-body attachment.
+    pub fn jointSetLocalFrame1(&mut self, handle: FlatHandle, anchor: &RawVector, rot: &RawRotation) {
+        self.map_mut(handle, |j| {
+            j.data.set_local_frame1(Isometry::from_parts(anchor.0.into(), rot.0));
+        });
+    }
+
+    /// Sets the full local frame (anchor + rotation) for the second rigid-body attachment.
+    pub fn jointSetLocalFrame2(&mut self, handle: FlatHandle, anchor: &RawVector, rot: &RawRotation) {
+        self.map_mut(handle, |j| {
+            j.data.set_local_frame2(Isometry::from_parts(anchor.0.into(), rot.0));
+        });
     }
 
     /// Are contacts between the rigid-bodies attached by this joint enabled?


### PR DESCRIPTION
## Summary

This PR implements the frame transformation capabilities requested in #271, allowing users to set joint frames after joint creation.

## Changes

Added four new setter methods to `ImpulseJoint`:

- **`setFrameX1(rotation)`** - Sets the rotation frame for the first rigid-body attachment
- **`setFrameX2(rotation)`** - Sets the rotation frame for the second rigid-body attachment  
- **`setLocalFrame1(anchor, rotation)`** - Sets the full local frame (position + rotation) for the first attachment
- **`setLocalFrame2(anchor, rotation)`** - Sets the full local frame (position + rotation) for the second attachment

These complement the existing `frameX1()` and `frameX2()` getters, providing symmetric read/write access to joint frames.

## Motivation

Joint frames are currently read-only in the JavaScript bindings despite being settable in the Rust API. This limitation prevents adjustments to joint configurations after creation.

## Testing

The implementation delegates directly to Rapier's safe abstractions (`set_local_frame1` / `set_local_frame2`), following the same pattern as existing anchor setters. This has been used in a production application for several months without issues.

## Fixes

Fixes #271