### PR TITLE
Expose impulse joint motor max force

### DIFF
--- a/src.ts/dynamics/impulse_joint.ts
+++ b/src.ts/dynamics/impulse_joint.ts
@@ -272,6 +272,14 @@ export class UnitImpulseJoint extends ImpulseJoint {
         );
     }
 
+    public setMotorMaxForce(maxForce: number) {
+        this.rawSet.jointSetMotorMaxForce(
+            this.handle,
+            this.rawAxis(),
+            maxForce,
+        );
+    }
+
     public configureMotorVelocity(targetVel: number, factor: number) {
         this.rawSet.jointConfigureMotorVelocity(
             this.handle,

--- a/src/dynamics/impulse_joint.rs
+++ b/src/dynamics/impulse_joint.rs
@@ -108,6 +108,12 @@ impl RawImpulseJointSet {
         })
     }
 
+    pub fn jointSetMotorMaxForce(&mut self, handle: FlatHandle, axis: RawJointAxis, maxForce: f32) {
+        self.map_mut(handle, |j| {
+            j.data.set_motor_max_force(axis.into(), maxForce);
+        })
+    }
+
     /*
     #[cfg(feature = "dim3")]
     pub fn jointConfigureBallMotorVelocity(


### PR DESCRIPTION
## Summary

Expose `setMotorMaxForce(maxForce)` on `UnitImpulseJoint` for JavaScript users.

Rapier core already exposes this through `set_motor_max_force`, but the JS/WASM wrapper currently exposes motor model/velocity/position configuration without exposing the separate max-force setter.

## Why

This lets JS users cap solver-level joint motor force/torque directly instead of approximating motor force limits outside the joint solver. It is useful for cases like vehicle wheel motors, brakes, doors, and robotics where motor targets need a finite force limit.

## Changes

- Add `RawImpulseJointSet.jointSetMotorMaxForce(...)` in the wasm binding layer.
- Add `UnitImpulseJoint.setMotorMaxForce(maxForce)` in the TypeScript wrapper.

## Validation

- `cargo check -p dimforge_rapier3d`
- `cargo fmt --check -- src/dynamics/impulse_joint.rs`
- `npx prettier --check src.ts/dynamics/impulse_joint.ts`
